### PR TITLE
docs(adr): Reviewed ADR-001

### DIFF
--- a/docs/architecture/adr-001-poap-contract.md
+++ b/docs/architecture/adr-001-poap-contract.md
@@ -207,7 +207,7 @@ pub struct QueryEventInfoResponse {
   pub creator: Addr,
   pub start_time: Timestamp,
   pub end_time: Timestamp,
-  pub event_uri: String,
+  pub poap_uri: String,
 }
 ```
 

--- a/docs/architecture/adr-001-poap-contract.md
+++ b/docs/architecture/adr-001-poap-contract.md
@@ -1,4 +1,4 @@
-# ADR 001: POAP-Contract
+# ADR 001: POAP Contract
 
 ## Changelog
 
@@ -8,10 +8,11 @@
 - July 12, 2022: Fourth review.
 - July 14, 2022: Fifth review;
 - July 15, 2022: Sixth review;
-- July 18, 2022: Accepted ADR.
+- July 18, 2022: Accepted ADR;
+- August 8, 2022: Reviewed ADR.
 
 ## Status
-ACCEPTED (Not implemented)
+ACCEPTED (Implemented)
 
 ## Abstract
 This ADR defines the architecture of a [**POAP**](https://academy.binance.com/en/glossary/proof-of-attendance-protocol-poap) generator contract.
@@ -79,8 +80,7 @@ pub struct EventInfo {
     pub start_time: Timestamp,
     pub end_time: Timestamp,
     pub per_address_limit: u32,
-    pub base_poap_uri: String,
-    pub event_uri: String,
+    pub poap_uri: String,
     pub cw721_code_id: u64,
 }
 ```
@@ -89,24 +89,62 @@ pub struct EventInfo {
 * The `start_time` identifies the start time of the event;
 * The `end_time` identifies the end time of the event;
 * The `per_address_limit` identifies the max num of tokens that can be minted by an address;
-* The `base_poap_uri` identifies a valid `IPFS` URI corresponding to where the assets and metadata of the POAPs are stored.
+* The `poap_uri` identifies a valid `IPFS` URI corresponding to where the asset and metadata of the POAP are stored.
   * The `metadata` file is a `.json` that follow the `ERC-721` [metadata standard](https://docs.opensea.io/docs/metadata-standards#metadata-structure)
 * The field will be used to initialize the `token_uri` field of the `cw721-base` [`MintMsg<T>`](https://github.com/CosmWasm/cw-nfts/blob/1e992ccf640f07a384d6442625d6780a8e48ef1e/contracts/cw721-base/src/msg.rs#L61)
-* The `event_uri` field is used to initialize the `extension` part of the `cw721-base` [MintMsg< T >](https://github.com/CosmWasm/cw-nfts/blob/1e992ccf640f07a384d6442625d6780a8e48ef1e/contracts/cw721-base/src/msg.rs#L61) and contains a valid `IPFS` URI corresponding to where a `.json` file with the following event's metadata is stored:
-
+The metadata should be filled as the following ones:
 ```json
 {
-  "name": "My awesome event",
-  "description": "Brief description of the event",
-  "city": "city where the event will be taking place",
-  "country": "country where the event will be taking place",
-  "start_date": "Start date for your event",
-  "end_date": "End date for your event, no attendees will be able to mint POAPs from your event",
-  "year": <number>,
-  "event_url": "Event URL",
-  "virtual_event": true or false,
+  "name": "POAP Cosmoverse",
+  "description": "Cosmoverse POAP badge",
+  "image": "ipfs://bafybeidyiza7igkgezh2uzma6dkbq7gmjzqrn6nwwoplm26qtj7i4mlbym/poap_cosmoverse.jpg",
+  "external_url": "https://twitter.com/CosmoverseHQ",
+  "animation_url": "ipfs://bafybeia5r3hwyou3iggzfvakjkxu2zy5pt3kjil6nyqzvrqwrrtkwe6xrm/images/poap_rotating.m4a"
+  "attributes": [
+    {
+      "display_type": "City",
+      "trait_type": "city",
+      "value": "Medellìn"
+    },
+    {
+      "display_type": "Country",
+      "trait_type": "country",
+      "value": "Colombia"
+    },
+    {
+      "display_type": "Coordinates",
+      "trait_type": "coordinates",
+      "value": "6.2476° N, 75.5658° W"
+    },
+    {
+      "display_type": "Start date",
+      "trait_type": "start_date",
+      "value": "2022-09-26T09:00:00.000000000Z"
+    },
+    {
+      "display_type": "End date",
+      "trait_type": "end_date",
+      "value": "2022-09-26T09:00:00.000000000Z"
+    },
+    {
+      "display_type": "Year",
+      "trait_type": "year",
+      "value": 2022
+    },
+    {
+      "display_type": "Event website",
+      "trait_type": "event_website",
+      "value": "https://www.cosmoverse.com"
+    },
+    {
+      "display_type": "Virtual Event",
+      "trait_type": "virtual_event",
+      "value": false
+    }
+  ]
 }
 ```
+* The `cw721_code_id` identifies the code of the `CW721-base` contract initialised by this contract.
 
 #### Execute
 ```rust


### PR DESCRIPTION
Removed the usage of the extention field of cw 721 base, as well the `event_uri` field. Now the event metadata are merged with the POAP metadata.