### PR TITLE
fix: removed the event uri and just use the poap uri for metadata

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,18 @@
+queue_rules:
+  - name: default
+    conditions:
+      - base=master
+
+pull_request_rules:
+  - name: automerge to master with label automerge and branch protection passing
+    conditions:
+      - "#approved-reviews-by>1"
+      - label=automerge
+    actions:
+      queue:
+        name: default
+        method: squash
+        commit_message_template: >
+          {{ title }} (#{{ number }})
+          
+          {{ body }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,22 +349,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "example"
-version = "0.1.0"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "cosmwasm-storage",
- "cw-multi-test",
- "cw-storage-plus",
- "cw2",
- "desmos-bindings",
- "schemars",
- "serde",
- "thiserror",
-]
-
-[[package]]
 name = "ff"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/contracts/poap-manager/src/contract.rs
+++ b/contracts/poap-manager/src/contract.rs
@@ -219,8 +219,7 @@ mod tests {
                     start_time: Timestamp::from_seconds(10),
                     end_time: Timestamp::from_seconds(20),
                     per_address_limit: 2,
-                    base_poap_uri: "ipfs://popap-uri".to_string(),
-                    event_uri: "ipfs://event-uri".to_string(),
+                    poap_uri: "ipfs://popap-uri".to_string(),
                 },
             },
         }
@@ -255,8 +254,7 @@ mod tests {
                     start_time: Timestamp::from_seconds(10),
                     end_time: Timestamp::from_seconds(20),
                     per_address_limit: 2,
-                    base_poap_uri: "ipfs://popap-uri".to_string(),
-                    event_uri: "ipfs://event-uri".to_string(),
+                    poap_uri: "ipfs://popap-uri".to_string(),
                 },
             },
         };
@@ -288,8 +286,7 @@ mod tests {
                     start_time: Timestamp::from_seconds(10),
                     end_time: Timestamp::from_seconds(20),
                     per_address_limit: 2,
-                    base_poap_uri: "ipfs://popap-uri".to_string(),
-                    event_uri: "ipfs://event-uri".to_string(),
+                    poap_uri: "ipfs://popap-uri".to_string(),
                 },
             },
         };

--- a/contracts/poap-manager/src/integration_tests.rs
+++ b/contracts/poap-manager/src/integration_tests.rs
@@ -61,8 +61,7 @@ mod tests {
                     start_time: Timestamp::from_seconds(10),
                     end_time: Timestamp::from_seconds(20),
                     per_address_limit: 2,
-                    base_poap_uri: "ipfs://popap-uri".to_string(),
-                    event_uri: "ipfs://event-uri".to_string(),
+                    poap_uri: "ipfs://popap-uri".to_string(),
                 },
             },
         }

--- a/contracts/poap-manager/src/msg.rs
+++ b/contracts/poap-manager/src/msg.rs
@@ -77,8 +77,7 @@ mod tests {
                     start_time: Timestamp::from_seconds(10),
                     end_time: Timestamp::from_seconds(20),
                     per_address_limit: 2,
-                    base_poap_uri: "ipfs://popap-uri".to_string(),
-                    event_uri: "ipfs://event-uri".to_string(),
+                    poap_uri: "ipfs://popap-uri".to_string(),
                 },
             },
         };
@@ -105,8 +104,7 @@ mod tests {
                     start_time: Timestamp::from_seconds(10),
                     end_time: Timestamp::from_seconds(20),
                     per_address_limit: 2,
-                    base_poap_uri: "ipfs://popap-uri".to_string(),
-                    event_uri: "ipfs://event-uri".to_string(),
+                    poap_uri: "ipfs://popap-uri".to_string(),
                 },
             },
         };

--- a/contracts/poap-manager/src/test_utils.rs
+++ b/contracts/poap-manager/src/test_utils.rs
@@ -87,7 +87,7 @@ impl CW721TestContract {
         info: MessageInfo,
         msg: Cw721InstantiateMsg,
     ) -> Result<Response<DesmosMsg>, StdError> {
-        Cw721Contract::<'static, String, Empty, Empty, DesmosMsg, DesmosQuery>::default()
+        Cw721Contract::<'static, Empty, Empty, Empty, DesmosMsg, DesmosQuery>::default()
             .instantiate(deps, env, info, msg)
     }
 
@@ -104,14 +104,14 @@ impl CW721TestContract {
         deps: DepsMut<DesmosQuery>,
         env: Env,
         info: MessageInfo,
-        msg: Cw721ExecuteMsg<String, Empty>,
+        msg: Cw721ExecuteMsg<Empty, Empty>,
     ) -> Result<Response<DesmosMsg>, Cw721ContractError> {
-        Cw721Contract::<'static, String, Empty, Empty, DesmosMsg, DesmosQuery>::default()
+        Cw721Contract::<'static, Empty, Empty, Empty, DesmosMsg, DesmosQuery>::default()
             .execute(deps, env, info, msg)
     }
 
     fn query(deps: Deps<DesmosQuery>, env: Env, msg: Cw721QueryMsg<Empty>) -> StdResult<Binary> {
-        Cw721Contract::<'static, String, Empty, Empty, DesmosMsg, DesmosQuery>::default()
+        Cw721Contract::<'static, Empty, Empty, Empty, DesmosMsg, DesmosQuery>::default()
             .query(deps, env, msg)
     }
 

--- a/contracts/poap/src/cw721_test_utils.rs
+++ b/contracts/poap/src/cw721_test_utils.rs
@@ -10,9 +10,9 @@ fn cw721_execute(
     deps: DepsMut<DesmosQuery>,
     env: Env,
     info: MessageInfo,
-    msg: Cw721ExecuteMsg<String, Empty>,
+    msg: Cw721ExecuteMsg<Empty, Empty>,
 ) -> Result<Response<DesmosMsg>, Cw721ContractError> {
-    Cw721Contract::<'static, String, Empty, Empty, DesmosMsg, DesmosQuery>::default()
+    Cw721Contract::<'static, Empty, Empty, Empty, DesmosMsg, DesmosQuery>::default()
         .execute(deps, env, info, msg)
 }
 

--- a/contracts/poap/src/cw721_test_utils.rs
+++ b/contracts/poap/src/cw721_test_utils.rs
@@ -22,7 +22,7 @@ fn cw721_instantiate(
     info: MessageInfo,
     msg: Cw721InstantiateMsg,
 ) -> Result<Response<DesmosMsg>, StdError> {
-    Cw721Contract::<'static, String, Empty, Empty, DesmosMsg, DesmosQuery>::default()
+    Cw721Contract::<'static, Empty, Empty, Empty, DesmosMsg, DesmosQuery>::default()
         .instantiate(deps, env, info, msg)
 }
 
@@ -36,7 +36,7 @@ fn failing_cw721_instantiate(
 }
 
 fn cw721_query(deps: Deps<DesmosQuery>, env: Env, msg: Cw721QueryMsg<Empty>) -> StdResult<Binary> {
-    Cw721Contract::<'static, String, Empty, Empty, DesmosMsg, DesmosQuery>::default()
+    Cw721Contract::<'static, Empty, Empty, Empty, DesmosMsg, DesmosQuery>::default()
         .query(deps, env, msg)
 }
 

--- a/contracts/poap/src/error.rs
+++ b/contracts/poap/src/error.rs
@@ -30,14 +30,11 @@ pub enum ContractError {
         end_time: Timestamp,
     },
 
-    #[error("Invalid base poap URI (must be an IPFS URI)")]
+    #[error("Invalid poap URI (must be an IPFS URI)")]
     InvalidPoapUri {},
 
     #[error("Invalid per address limit value")]
     InvalidPerAddressLimit {},
-
-    #[error("Invalid event URI")]
-    InvalidEventUri {},
 
     #[error("Mint operation is disabled")]
     MintDisabled {},

--- a/contracts/poap/src/integration_tests.rs
+++ b/contracts/poap/src/integration_tests.rs
@@ -6,8 +6,8 @@ mod tests {
         QueryMsg,
     };
     use crate::test_utils::{
-        get_valid_init_msg, ADMIN, CREATOR, EVENT_END_SECONDS, EVENT_START_SECONDS, EVENT_URI,
-        INITIAL_BLOCK_TIME_SECONDS, MINTER, USER,
+        get_valid_init_msg, ADMIN, CREATOR, EVENT_END_SECONDS, EVENT_START_SECONDS,
+        INITIAL_BLOCK_TIME_SECONDS, MINTER, POAP_URI, USER,
     };
     use cosmwasm_std::{Addr, Empty, Timestamp, Uint64};
     use cw721::TokensResponse;
@@ -134,7 +134,7 @@ mod tests {
             Timestamp::from_seconds(EVENT_END_SECONDS),
             poap_event_info.end_time
         );
-        assert_eq!(EVENT_URI, poap_event_info.event_uri.as_str());
+        assert_eq!(POAP_URI, poap_event_info.poap_uri.as_str());
 
         let cw721_minter_response: MinterResponse = querier
             .query_wasm_smart(

--- a/contracts/poap/src/msg.rs
+++ b/contracts/poap/src/msg.rs
@@ -30,9 +30,7 @@ pub struct EventInfo {
     /// Max amount of poap that a single user can mint.
     pub per_address_limit: u32,
     /// Identifies a valid IPFS URI corresponding to where the assets and metadata of the POAPs are stored.
-    pub base_poap_uri: String,
-    /// Uri of the poap event
-    pub event_uri: String,
+    pub poap_uri: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -99,7 +97,7 @@ pub struct QueryEventInfoResponse {
     /// Time at which the event ends.
     pub end_time: Timestamp,
     /// IPFS uri where the event's metadata are stored
-    pub event_uri: String,
+    pub poap_uri: String,
 }
 
 /// Response to [`QueryMsg::MintedAmount`].
@@ -129,17 +127,10 @@ impl InstantiateMsg {
         }
 
         // Check that the poap uri is a valid IPFS url
-        let poap_uri = Url::parse(&self.event_info.base_poap_uri)
+        let poap_uri = Url::parse(&self.event_info.poap_uri)
             .map_err(|_err| ContractError::InvalidPoapUri {})?;
         if poap_uri.scheme() != "ipfs" {
             return Err(ContractError::InvalidPoapUri {});
-        }
-
-        // Check that the event uri is a valid IPFS url
-        let event_uri = Url::parse(&self.event_info.event_uri)
-            .map_err(|_err| ContractError::InvalidEventUri {})?;
-        if event_uri.scheme() != "ipfs" {
-            return Err(ContractError::InvalidEventUri {});
         }
 
         Ok(())
@@ -194,8 +185,7 @@ mod tests {
                 start_time: start.clone(),
                 end_time: end.clone(),
                 per_address_limit: 1,
-                base_poap_uri: "ipfs://domain.com".to_string(),
-                event_uri: "ipfs://domain.com".to_string(),
+                poap_uri: "ipfs://domain.com".to_string(),
             },
         };
 
@@ -223,8 +213,7 @@ mod tests {
                 start_time: start.clone(),
                 end_time: end.clone(),
                 per_address_limit: 1,
-                base_poap_uri: "ipfs://domain.com".to_string(),
-                event_uri: "ipfs://domain.com".to_string(),
+                poap_uri: "ipfs://domain.com".to_string(),
             },
         };
 
@@ -250,8 +239,7 @@ mod tests {
                 start_time: Timestamp::from_seconds(1),
                 end_time: Timestamp::from_seconds(2),
                 per_address_limit: 0,
-                base_poap_uri: "ipfs://domain.com".to_string(),
-                event_uri: "ipfs://domain.com".to_string(),
+                poap_uri: "ipfs://domain.com".to_string(),
             },
         };
 
@@ -262,7 +250,7 @@ mod tests {
     }
 
     #[test]
-    fn instantiate_with_invalid_event_uri_error() {
+    fn instantiate_with_invalid_poap_uri_error() {
         let msg = InstantiateMsg {
             admin: "".to_string(),
             minter: "".to_string(),
@@ -277,62 +265,7 @@ mod tests {
                 start_time: Timestamp::from_seconds(1),
                 end_time: Timestamp::from_seconds(2),
                 per_address_limit: 1,
-                base_poap_uri: "ipfs://domain.com".to_string(),
-                event_uri: "invalid_event_uri".to_string(),
-            },
-        };
-
-        assert_eq!(
-            ContractError::InvalidEventUri {},
-            msg.validate().unwrap_err()
-        );
-    }
-
-    #[test]
-    fn instantiate_with_non_ipfs_event_uri_error() {
-        let msg = InstantiateMsg {
-            admin: "".to_string(),
-            minter: "".to_string(),
-            cw721_code_id: 0u64.into(),
-            cw721_initiate_msg: Cw721InstantiateMsg {
-                name: "".to_string(),
-                minter: "".to_string(),
-                symbol: "".to_string(),
-            },
-            event_info: EventInfo {
-                creator: "".to_string(),
-                start_time: Timestamp::from_seconds(1),
-                end_time: Timestamp::from_seconds(2),
-                per_address_limit: 1,
-                base_poap_uri: "ipfs://domain.com".to_string(),
-                event_uri: "https://domain.com".to_string(),
-            },
-        };
-
-        assert_eq!(
-            ContractError::InvalidEventUri {},
-            msg.validate().unwrap_err()
-        );
-    }
-
-    #[test]
-    fn instantiate_with_invalid_base_poap_uri_error() {
-        let msg = InstantiateMsg {
-            admin: "".to_string(),
-            minter: "".to_string(),
-            cw721_code_id: 0u64.into(),
-            cw721_initiate_msg: Cw721InstantiateMsg {
-                name: "".to_string(),
-                minter: "".to_string(),
-                symbol: "".to_string(),
-            },
-            event_info: EventInfo {
-                creator: "".to_string(),
-                start_time: Timestamp::from_seconds(1),
-                end_time: Timestamp::from_seconds(2),
-                per_address_limit: 1,
-                base_poap_uri: "invalid_base_poap_uri".to_string(),
-                event_uri: "ipfs://domain.com".to_string(),
+                poap_uri: "invalid_base_poap_uri".to_string(),
             },
         };
 
@@ -343,7 +276,7 @@ mod tests {
     }
 
     #[test]
-    fn instantiate_with_non_ipfs_base_poap_uri_error() {
+    fn instantiate_with_non_ipfs_poap_uri_error() {
         let msg = InstantiateMsg {
             admin: "".to_string(),
             minter: "".to_string(),
@@ -358,8 +291,7 @@ mod tests {
                 start_time: Timestamp::from_seconds(1),
                 end_time: Timestamp::from_seconds(2),
                 per_address_limit: 1,
-                base_poap_uri: "https://domain.com".to_string(),
-                event_uri: "ipfs://domain.com".to_string(),
+                poap_uri: "https://domain.com".to_string(),
             },
         };
 

--- a/contracts/poap/src/state.rs
+++ b/contracts/poap/src/state.rs
@@ -18,8 +18,7 @@ pub struct EventInfo {
     pub creator: Addr,
     pub start_time: Timestamp,
     pub end_time: Timestamp,
-    pub base_poap_uri: String,
-    pub event_uri: String,
+    pub poap_uri: String,
 }
 
 pub const CONFIG: Item<Config> = Item::new("config");
@@ -58,8 +57,7 @@ mod tests {
             creator: Addr::unchecked(""),
             start_time: Timestamp::from_seconds(start),
             end_time: Timestamp::from_seconds(end),
-            base_poap_uri: "".to_string(),
-            event_uri: "".to_string(),
+            poap_uri: "".to_string(),
         }
     }
 

--- a/contracts/poap/src/test_utils.rs
+++ b/contracts/poap/src/test_utils.rs
@@ -9,7 +9,7 @@ pub const CREATOR: &str = "creator";
 pub const ADMIN: &str = "admin";
 pub const MINTER: &str = "minter";
 pub const USER: &str = "user";
-pub const EVENT_URI: &str = "ipfs://event-uri";
+pub const POAP_URI: &str = "ipfs://poap-uri";
 
 pub fn get_valid_init_msg(cw721_code_id: u64) -> InstantiateMsg {
     let start_time = Timestamp::from_seconds(EVENT_START_SECONDS);
@@ -29,8 +29,7 @@ pub fn get_valid_init_msg(cw721_code_id: u64) -> InstantiateMsg {
             start_time,
             end_time,
             per_address_limit: 2,
-            base_poap_uri: "ipfs://popap-uri".to_string(),
-            event_uri: EVENT_URI.to_string(),
+            poap_uri: POAP_URI.to_string(),
         },
     }
 }


### PR DESCRIPTION
This PR implementes the latest changes from ADR-01 on POAP contract and updates the POAP manager to make it compatible.