### PR TITLE
fix: fixed poap manager query msg to be snake case

### DIFF
--- a/contracts/poap-manager/schema/instantiate_msg.json
+++ b/contracts/poap-manager/schema/instantiate_msg.json
@@ -33,18 +33,13 @@
     "EventInfo": {
       "type": "object",
       "required": [
-        "base_poap_uri",
         "creator",
         "end_time",
-        "event_uri",
         "per_address_limit",
+        "poap_uri",
         "start_time"
       ],
       "properties": {
-        "base_poap_uri": {
-          "description": "Identifies a valid IPFS URI corresponding to where the assets and metadata of the POAPs are stored.",
-          "type": "string"
-        },
         "creator": {
           "description": "User that created the event.",
           "type": "string"
@@ -57,15 +52,15 @@
             }
           ]
         },
-        "event_uri": {
-          "description": "Uri of the poap event",
-          "type": "string"
-        },
         "per_address_limit": {
           "description": "Max amount of poap that a single user can mint.",
           "type": "integer",
           "format": "uint32",
           "minimum": 0.0
+        },
+        "poap_uri": {
+          "description": "Identifies a valid IPFS URI corresponding to where the assets and metadata of the POAPs are stored.",
+          "type": "string"
         },
         "start_time": {
           "description": "Time at which the event begins.",

--- a/contracts/poap-manager/schema/query_msg.json
+++ b/contracts/poap-manager/schema/query_msg.json
@@ -6,10 +6,10 @@
       "description": "Return a ConfigResponse containing the configuration info of the Manager contract",
       "type": "object",
       "required": [
-        "Config"
+        "config"
       ],
       "properties": {
-        "Config": {
+        "config": {
           "type": "object"
         }
       },

--- a/contracts/poap-manager/src/msg.rs
+++ b/contracts/poap-manager/src/msg.rs
@@ -36,6 +36,7 @@ pub enum ExecuteMsg {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
     /// Return a ConfigResponse containing the configuration info of the Manager contract
     Config {},

--- a/contracts/poap/schema/event_info.json
+++ b/contracts/poap/schema/event_info.json
@@ -3,23 +3,19 @@
   "title": "EventInfo",
   "type": "object",
   "required": [
-    "base_poap_uri",
     "creator",
     "end_time",
-    "event_uri",
+    "poap_uri",
     "start_time"
   ],
   "properties": {
-    "base_poap_uri": {
-      "type": "string"
-    },
     "creator": {
       "$ref": "#/definitions/Addr"
     },
     "end_time": {
       "$ref": "#/definitions/Timestamp"
     },
-    "event_uri": {
+    "poap_uri": {
       "type": "string"
     },
     "start_time": {

--- a/contracts/poap/schema/instantiate_msg.json
+++ b/contracts/poap/schema/instantiate_msg.json
@@ -47,18 +47,13 @@
     "EventInfo": {
       "type": "object",
       "required": [
-        "base_poap_uri",
         "creator",
         "end_time",
-        "event_uri",
         "per_address_limit",
+        "poap_uri",
         "start_time"
       ],
       "properties": {
-        "base_poap_uri": {
-          "description": "Identifies a valid IPFS URI corresponding to where the assets and metadata of the POAPs are stored.",
-          "type": "string"
-        },
         "creator": {
           "description": "User that created the event.",
           "type": "string"
@@ -71,15 +66,15 @@
             }
           ]
         },
-        "event_uri": {
-          "description": "Uri of the poap event",
-          "type": "string"
-        },
         "per_address_limit": {
           "description": "Max amount of poap that a single user can mint.",
           "type": "integer",
           "format": "uint32",
           "minimum": 0.0
+        },
+        "poap_uri": {
+          "description": "Identifies a valid IPFS URI corresponding to where the assets and metadata of the POAPs are stored.",
+          "type": "string"
         },
         "start_time": {
           "description": "Time at which the event begins.",

--- a/contracts/poap/schema/query_event_info_response.json
+++ b/contracts/poap/schema/query_event_info_response.json
@@ -6,7 +6,7 @@
   "required": [
     "creator",
     "end_time",
-    "event_uri",
+    "poap_uri",
     "start_time"
   ],
   "properties": {
@@ -26,7 +26,7 @@
         }
       ]
     },
-    "event_uri": {
+    "poap_uri": {
       "description": "IPFS uri where the event's metadata are stored",
       "type": "string"
     },


### PR DESCRIPTION
This PR fixes the query naming of `poap-manager` contract to be snake case, then update the schema files.
deps: #45