### PR TITLE
refactor: fix generated poap-manager json schema

### DIFF
--- a/contracts/poap-manager/schema/instantiate_msg.json
+++ b/contracts/poap-manager/schema/instantiate_msg.json
@@ -24,7 +24,7 @@
       "description": "Initialization message of the POAP contract.",
       "allOf": [
         {
-          "$ref": "#/definitions/InstantiateMsg"
+          "$ref": "#/definitions/PoapInstantiateMsg"
         }
       ]
     }
@@ -73,6 +73,29 @@
       }
     },
     "InstantiateMsg": {
+      "type": "object",
+      "required": [
+        "minter",
+        "name",
+        "symbol"
+      ],
+      "properties": {
+        "minter": {
+          "description": "The minter is the only one who can create new NFTs. This is designed for a base NFT that is controlled by an external program or contract. You will likely replace this with custom logic in custom NFTs",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the NFT contract",
+          "type": "string"
+        },
+        "symbol": {
+          "description": "Symbol of the NFT contract",
+          "type": "string"
+        }
+      }
+    },
+    "PoapInstantiateMsg": {
+      "title": "InstantiateMsg",
       "type": "object",
       "required": [
         "admin",

--- a/contracts/poap-manager/src/msg.rs
+++ b/contracts/poap-manager/src/msg.rs
@@ -6,6 +6,7 @@ use crate::error::ContractError;
 use poap::msg::InstantiateMsg as POAPInstantiateMsg;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[schemars(rename = "PoapManagerInstantiateMsg", title = "InstantiateMsg")]
 pub struct InstantiateMsg {
     /// Address of who will have the right to administer the contract.
     pub admin: String,

--- a/contracts/poap/schema/state_event_info.json
+++ b/contracts/poap/schema/state_event_info.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "EventInfo",
+  "title": "StateEventInfo",
   "type": "object",
   "required": [
     "creator",

--- a/contracts/poap/src/msg.rs
+++ b/contracts/poap/src/msg.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use url::Url;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[schemars(rename = "PoapInstantiateMsg", title = "InstantiateMsg")]
 pub struct InstantiateMsg {
     /// Address of who will have the right to administer the contract.
     pub admin: String,

--- a/contracts/poap/src/state.rs
+++ b/contracts/poap/src/state.rs
@@ -14,6 +14,7 @@ pub struct Config {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[schemars(rename = "StateEventInfo")]
 pub struct EventInfo {
     pub creator: Addr,
     pub start_time: Timestamp,


### PR DESCRIPTION
This PR fixes a type name collission in the generated json schema of `poap-manager`.
The `InstantiateMsg` of `poap-manager` contains the `poap` `InstantiateMsg` that contains the `cw721` `InstantiateMsg`  this causes a type name collision between the poap and cw721 `InstantiateMsg` because both have the same type name resulting in a schema that have the wrong type for the field `cw721_initiate_msg` of the poap  `InstantiateMsg` .
To avoid the name collission I used the schemars attribute `rename` to change the type name and the schemars `title` attribute to preserve the file name of the generated json schemas.
[Here](https://github.com/GREsau/schemars/blob/00e482c3a19e7b3e15f8a0de99c7d717bf96595f/docs/1.1-attributes.md#title-description) the documentation related to the schemars attributes.