### PR TITLE
build(ci): run lint tests only if a .rs file is changed

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,14 +15,14 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Verify .rs files 👀
-        uses: tj-actions/verify-changed-files@v11.1
-        id: verify-changed-files
+        uses: technote-space/get-diff-action@v6.1.0
+        id: git_diff
         with:
-          files: |
-            **/*.rs
+          PATTERNS: |
+            **/**.rs
 
       - name: Setup Rust ⚙
-        if: steps.verify-changed-files.outputs.files_changed == 'true'
+        if: env.GIT_DIFF
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -31,21 +31,21 @@ jobs:
           components: rustfmt, clippy
 
       - name: Run cargo fmt ✅
-        if: steps.verify-changed-files.outputs.files_changed == 'true'
+        if: env.GIT_DIFF
         run: cargo fmt --all -- --check
 
       - name: Run cargo clippy ✅
-        if: steps.verify-changed-files.outputs.files_changed == 'true'
+        if: env.GIT_DIFF
         run: cargo clippy
 
       - name: Generate coverage report 🧪
-        if: steps.verify-changed-files.outputs.files_changed == 'true'
+        if: env.GIT_DIFF
         uses: actions-rs/tarpaulin@v0.1.3
         with:
           args: '--avoid-cfg-tarpaulin'
 
       - name: Upload coverage 📤
-        if: steps.verify-changed-files.outputs.files_changed == 'true'
+        if: env.GIT_DIFF
         uses: codecov/codecov-action@v1.0.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,15 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v2
 
-      - name: Setup Rust ⚙️
+      - name: Verify .rs files 👀
+        uses: tj-actions/verify-changed-files@v11.1
+        id: verify-changed-files
+        with:
+          files: |
+            **/*.rs
+
+      - name: Setup Rust ⚙
+        if: steps.verify-changed-files.outputs.files_changed == 'true'
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -23,7 +31,21 @@ jobs:
           components: rustfmt, clippy
 
       - name: Run cargo fmt ✅
+        if: steps.verify-changed-files.outputs.files_changed == 'true'
         run: cargo fmt --all -- --check
 
       - name: Run cargo clippy ✅
+        if: steps.verify-changed-files.outputs.files_changed == 'true'
         run: cargo clippy
+
+      - name: Generate coverage report 🧪
+        if: steps.verify-changed-files.outputs.files_changed == 'true'
+        uses: actions-rs/tarpaulin@v0.1.3
+        with:
+          args: '--avoid-cfg-tarpaulin'
+
+      - name: Upload coverage 📤
+        if: steps.verify-changed-files.outputs.files_changed == 'true'
+        uses: codecov/codecov-action@v1.0.2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,13 +14,23 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v2
 
+      - name: Verify .rs and toml files 👀
+        uses: technote-space/get-diff-action@v6.1.0
+        id: git_diff
+        with:
+          PATTERNS: |
+            **/**.rs
+            **/**.toml
+
       - name: Setup Rust ⚙️
+        if: env.GIT_DIFF
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           override: true
 
       - name: Test contracts 🧪
+        if: env.GIT_DIFF
         run: cargo test
         env:
           RUST_BACKTRACE: 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,22 +20,7 @@ jobs:
           toolchain: stable
           override: true
 
-      - name: Generate coverage report 🧪
-        uses: actions-rs/tarpaulin@v0.1.3
-        with:
-          args: '--avoid-cfg-tarpaulin'
-
-      - name: Upload coverage 📤
-        uses: codecov/codecov-action@v1.0.2
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Test POAP contract 🧪
-        run: cargo test --package poap
-        env:
-          RUST_BACKTRACE: 1
-
-      - name: Test POAP manager contract 🧪
-        run: cargo test --package poap-manager
+      - name: Test contracts 🧪
+        run: cargo test
         env:
           RUST_BACKTRACE: 1


### PR DESCRIPTION
This PR updates the CI workflow to run the lint check only if a `.rs` file is changed in order to reduce the amount of time required to performs the automatic checks