### PR TITLE
build: bump desmos-bindings to 1.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,25 +195,6 @@ dependencies = [
 
 [[package]]
 name = "cw-multi-test"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f9a8ab7c3c29ec93cb7a39ce4b14a05e053153b4a17ef7cf2246af1b7c087e"
-dependencies = [
- "anyhow",
- "cosmwasm-std",
- "cosmwasm-storage",
- "cw-storage-plus 0.13.4",
- "cw-utils 0.13.4",
- "derivative",
- "itertools",
- "prost",
- "schemars",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "cw-multi-test"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2519fd64b6b8c7c4e77c317e665bd19b438db3e8e4867241fa6a31cf060feda9"
@@ -375,7 +356,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-multi-test 0.13.4",
+ "cw-multi-test",
  "cw-storage-plus 0.15.0",
  "cw2 0.15.0",
  "cw721",
@@ -393,7 +374,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-multi-test 0.13.4",
+ "cw-multi-test",
  "cw-storage-plus 0.14.0",
  "cw2 0.14.0",
  "cw721",
@@ -433,7 +414,7 @@ checksum = "67ba3e792552d6960b0205994a4fca5e83daffb12b93f7ca9ac86c99d703b805"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
- "cw-multi-test 0.15.0",
+ "cw-multi-test",
  "schemars",
  "serde",
  "thiserror",
@@ -673,7 +654,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-multi-test 0.13.4",
+ "cw-multi-test",
  "cw-storage-plus 0.15.0",
  "cw-utils 0.15.0",
  "cw2 0.15.0",
@@ -694,7 +675,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-multi-test 0.13.4",
+ "cw-multi-test",
  "cw-storage-plus 0.15.0",
  "cw-utils 0.15.0",
  "cw2 0.15.0",
@@ -774,10 +755,10 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-multi-test 0.13.4",
- "cw-storage-plus 0.13.4",
- "cw-utils 0.14.0",
- "cw2 0.13.4",
+ "cw-multi-test",
+ "cw-storage-plus 0.15.0",
+ "cw-utils 0.15.0",
+ "cw2 0.15.0",
  "cw721",
  "cw721-base",
  "cw721-remarkables",
@@ -1009,7 +990,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-multi-test 0.13.4",
+ "cw-multi-test",
  "cw-storage-plus 0.14.0",
  "cw-utils 0.14.0",
  "cw2 0.14.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,25 +213,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cw-multi-test"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2519fd64b6b8c7c4e77c317e665bd19b438db3e8e4867241fa6a31cf060feda9"
-dependencies = [
- "anyhow",
- "cosmwasm-std",
- "cosmwasm-storage",
- "cw-storage-plus 0.15.0",
- "cw-utils 0.15.0",
- "derivative",
- "itertools",
- "prost",
- "schemars",
- "serde",
- "thiserror",
-]
-
-[[package]]
 name = "cw-storage-plus"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +253,20 @@ checksum = "9dbaecb78c8e8abfd6b4258c7f4fbeb5c49a5e45ee4d910d3240ee8e1d714e1b"
 dependencies = [
  "cosmwasm-std",
  "schemars",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "cw-utils"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "414b91f3d7a619bb26c835119d7095804596a1382ddc1d184c33c1d2c17f6c5e"
+dependencies = [
+ "cosmwasm-std",
+ "cw2 0.14.0",
+ "schemars",
+ "semver",
  "serde",
  "thiserror",
 ]
@@ -361,7 +356,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-multi-test 0.13.4",
+ "cw-multi-test",
  "cw-storage-plus 0.15.0",
  "cw2 0.15.0",
  "cw721",
@@ -379,7 +374,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-multi-test 0.13.4",
+ "cw-multi-test",
  "cw-storage-plus 0.14.0",
  "cw2 0.14.0",
  "cw721",
@@ -419,7 +414,7 @@ checksum = "67ba3e792552d6960b0205994a4fca5e83daffb12b93f7ca9ac86c99d703b805"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
- "cw-multi-test 0.15.0",
+ "cw-multi-test",
  "schemars",
  "serde",
  "thiserror",
@@ -659,7 +654,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-multi-test 0.13.4",
+ "cw-multi-test",
  "cw-storage-plus 0.15.0",
  "cw-utils 0.15.0",
  "cw2 0.15.0",
@@ -680,7 +675,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-multi-test 0.13.4",
+ "cw-multi-test",
  "cw-storage-plus 0.15.0",
  "cw-utils 0.15.0",
  "cw2 0.15.0",
@@ -760,10 +755,10 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-multi-test 0.13.4",
- "cw-storage-plus 0.13.4",
- "cw-utils 0.14.0",
- "cw2 0.13.4",
+ "cw-multi-test",
+ "cw-storage-plus 0.15.0",
+ "cw-utils 0.15.0",
+ "cw2 0.15.0",
  "cw721",
  "cw721-base",
  "cw721-remarkables",
@@ -995,10 +990,10 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-multi-test 0.13.4",
- "cw-storage-plus 0.14.0",
+ "cw-multi-test",
+ "cw-storage-plus 0.15.0",
  "cw-utils 0.14.0",
- "cw2 0.14.0",
+ "cw2 0.15.0",
  "desmos-bindings",
  "schemars",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cw-multi-test"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2519fd64b6b8c7c4e77c317e665bd19b438db3e8e4867241fa6a31cf060feda9"
+dependencies = [
+ "anyhow",
+ "cosmwasm-std",
+ "cosmwasm-storage",
+ "cw-storage-plus 0.15.0",
+ "cw-utils 0.15.0",
+ "derivative",
+ "itertools",
+ "prost",
+ "schemars",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "cw-storage-plus"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,7 +375,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-multi-test",
+ "cw-multi-test 0.13.4",
  "cw-storage-plus 0.15.0",
  "cw2 0.15.0",
  "cw721",
@@ -374,7 +393,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-multi-test",
+ "cw-multi-test 0.13.4",
  "cw-storage-plus 0.14.0",
  "cw2 0.14.0",
  "cw721",
@@ -408,13 +427,13 @@ dependencies = [
 
 [[package]]
 name = "desmos-bindings"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e00a5edd06750452275d23e37b18994976d21e73b01beaa65d7a0c8b194a67bf"
+checksum = "67ba3e792552d6960b0205994a4fca5e83daffb12b93f7ca9ac86c99d703b805"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
- "cw-multi-test",
+ "cw-multi-test 0.15.0",
  "schemars",
  "serde",
  "thiserror",
@@ -654,7 +673,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-multi-test",
+ "cw-multi-test 0.13.4",
  "cw-storage-plus 0.15.0",
  "cw-utils 0.15.0",
  "cw2 0.15.0",
@@ -675,7 +694,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-multi-test",
+ "cw-multi-test 0.13.4",
  "cw-storage-plus 0.15.0",
  "cw-utils 0.15.0",
  "cw2 0.15.0",
@@ -755,7 +774,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-multi-test",
+ "cw-multi-test 0.13.4",
  "cw-storage-plus 0.13.4",
  "cw-utils 0.14.0",
  "cw2 0.13.4",
@@ -990,7 +1009,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-multi-test",
+ "cw-multi-test 0.13.4",
  "cw-storage-plus 0.14.0",
  "cw-utils 0.14.0",
  "cw2 0.14.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cw-multi-test"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2519fd64b6b8c7c4e77c317e665bd19b438db3e8e4867241fa6a31cf060feda9"
+dependencies = [
+ "anyhow",
+ "cosmwasm-std",
+ "cosmwasm-storage",
+ "cw-storage-plus 0.15.0",
+ "cw-utils 0.15.0",
+ "derivative",
+ "itertools",
+ "prost",
+ "schemars",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "cw-storage-plus"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,7 +361,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-multi-test",
+ "cw-multi-test 0.13.4",
  "cw-storage-plus 0.15.0",
  "cw2 0.15.0",
  "cw721",
@@ -360,7 +379,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-multi-test",
+ "cw-multi-test 0.13.4",
  "cw-storage-plus 0.14.0",
  "cw2 0.14.0",
  "cw721",
@@ -400,7 +419,7 @@ checksum = "67ba3e792552d6960b0205994a4fca5e83daffb12b93f7ca9ac86c99d703b805"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
- "cw-multi-test",
+ "cw-multi-test 0.15.0",
  "schemars",
  "serde",
  "thiserror",
@@ -640,7 +659,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-multi-test",
+ "cw-multi-test 0.13.4",
  "cw-storage-plus 0.15.0",
  "cw-utils 0.15.0",
  "cw2 0.15.0",
@@ -661,7 +680,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-multi-test",
+ "cw-multi-test 0.13.4",
  "cw-storage-plus 0.15.0",
  "cw-utils 0.15.0",
  "cw2 0.15.0",
@@ -741,10 +760,10 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-multi-test",
- "cw-storage-plus 0.15.0",
- "cw-utils 0.15.0",
- "cw2 0.15.0",
+ "cw-multi-test 0.13.4",
+ "cw-storage-plus 0.13.4",
+ "cw-utils 0.14.0",
+ "cw2 0.13.4",
  "cw721",
  "cw721-base",
  "cw721-remarkables",
@@ -976,10 +995,10 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-multi-test",
- "cw-storage-plus 0.15.0",
- "cw-utils 0.15.0",
- "cw2 0.15.0",
+ "cw-multi-test 0.13.4",
+ "cw-storage-plus 0.14.0",
+ "cw-utils 0.14.0",
+ "cw2 0.14.0",
  "desmos-bindings",
  "schemars",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,20 +259,6 @@ dependencies = [
 
 [[package]]
 name = "cw-utils"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414b91f3d7a619bb26c835119d7095804596a1382ddc1d184c33c1d2c17f6c5e"
-dependencies = [
- "cosmwasm-std",
- "cw2 0.14.0",
- "schemars",
- "semver",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "cw-utils"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a67007ff056f4cd034f361c8ed69780c0180959b9c8037c84f3caa78120faf5"
@@ -992,7 +978,7 @@ dependencies = [
  "cosmwasm-storage",
  "cw-multi-test",
  "cw-storage-plus 0.15.0",
- "cw-utils 0.14.0",
+ "cw-utils 0.15.0",
  "cw2 0.15.0",
  "desmos-bindings",
  "schemars",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,31 +70,31 @@ checksum = "722e23542a15cea1f65d4a1419c4cfd7a26706c70871a13a04238ca3f40f1661"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7d659bbecbdca16878322becea489c0fcc36e784f41c942ea0171e9cf74179"
+checksum = "ce1c26e5595c6a960cd3d6dc1d8629e16a2b0cb22ecd653b28bbf292d7c53a3c"
 dependencies = [
- "digest 0.10.3",
+ "digest 0.10.5",
  "ed25519-zebra",
  "k256",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "thiserror",
 ]
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81b4676a316d3e4636f658d2d3aba9b4b30c3177e311bbda721b56d4a26342f"
+checksum = "0a24050753f242554c558dfe7a6b3a456850f2bc6fcf8b518988720e40a5fa21"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88917b0e7c987fd99251f8bb7e06da7d705e7572e0732428b72f8bc1f17b1af5"
+checksum = "9ce6fe57b9e59a87a406b825cbe647f6456e1a853f8d4c99bffcc20957fd29d6"
 dependencies = [
  "cosmwasm-schema-derive",
  "schemars",
@@ -105,9 +105,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03bd1495b8bc0130529dad7e69bef8d800654b50a5d5fc150f1e795c4c24c5b4"
+checksum = "62e8cfc90b557a8ed272c9daf0ff3634e6b9f4698a19832bba6a4c7baa46da04"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -116,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39d5725d2bd4b868284c127f7a904c93a9826550f30267b301484138db2eb9b"
+checksum = "78e50ba8bfea2e449be2e7fa96fd8b196d09fb5ef34e27a18f28835ed835b199"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -135,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc9b8229a8b09eb7673851f3e97cbb8832ae93a9d589800fa67ef1a2daef641"
+checksum = "6ce135cec6c90df7115b0f5b2b40683dd41ac62999dfb002107f6a9f5c345374"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -165,7 +165,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f2b443d17d49dad5ef0ede301c3179cc923b8822f3393b4d2c28c269dd4a122"
 dependencies = [
  "generic-array",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -195,32 +195,21 @@ dependencies = [
 
 [[package]]
 name = "cw-multi-test"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2519fd64b6b8c7c4e77c317e665bd19b438db3e8e4867241fa6a31cf060feda9"
+checksum = "e8e81b4a7821d5eeba0d23f737c16027b39a600742ca8c32eb980895ffd270f4"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-storage-plus 0.15.0",
- "cw-utils 0.15.0",
+ "cw-storage-plus 0.15.1",
+ "cw-utils",
  "derivative",
  "itertools",
  "prost",
  "schemars",
  "serde",
  "thiserror",
-]
-
-[[package]]
-name = "cw-storage-plus"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "648b1507290bbc03a8d88463d7cd9b04b1fa0155e5eef366c4fa052b9caaac7a"
-dependencies = [
- "cosmwasm-std",
- "schemars",
- "serde",
 ]
 
 [[package]]
@@ -236,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "cw-storage-plus"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ba3fb5fad2dce94263d070848b2befc46b5c8e4929adfb9a3595267823d6ec"
+checksum = "dc6cf70ef7686e2da9ad7b067c5942cd3e88dd9453f7af42f54557f8af300fb0"
 dependencies = [
  "cosmwasm-std",
  "schemars",
@@ -247,41 +236,17 @@ dependencies = [
 
 [[package]]
 name = "cw-utils"
-version = "0.13.4"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dbaecb78c8e8abfd6b4258c7f4fbeb5c49a5e45ee4d910d3240ee8e1d714e1b"
-dependencies = [
- "cosmwasm-std",
- "schemars",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "cw-utils"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a67007ff056f4cd034f361c8ed69780c0180959b9c8037c84f3caa78120faf5"
+checksum = "0ae0b69fa7679de78825b4edeeec045066aa2b2c4b6e063d80042e565bb4da5c"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw2 0.15.0",
+ "cw2 0.15.1",
  "schemars",
  "semver",
  "serde",
  "thiserror",
-]
-
-[[package]]
-name = "cw2"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cf4639517490dd36b333bbd6c4fbd92e325fd0acf4683b41753bc5eb63bfc1"
-dependencies = [
- "cosmwasm-std",
- "cw-storage-plus 0.13.4",
- "schemars",
- "serde",
 ]
 
 [[package]]
@@ -298,37 +263,39 @@ dependencies = [
 
 [[package]]
 name = "cw2"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0a1924a28607bf7cb9fd6681a64feea3e5fa9a8cb71fb4d24cf33635b21065a"
+checksum = "5abb8ecea72e09afff830252963cb60faf945ce6cef2c20a43814516082653da"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 0.15.0",
+ "cw-storage-plus 0.15.1",
  "schemars",
  "serde",
 ]
 
 [[package]]
 name = "cw721"
-version = "0.13.4"
-source = "git+https://github.com/desmos-labs/cw-nfts?branch=paul/update-custom-msg-query#c1c57511c42655fc4a321a28652c15904d1e7ae0"
+version = "0.15.0"
+source = "git+https://github.com/desmos-labs/cw-nfts?branch=paul/update-custom-msg-query#2aaa2a0f013874cf7792396f731a128d6440adfb"
 dependencies = [
+ "cosmwasm-schema",
  "cosmwasm-std",
- "cw-utils 0.13.4",
+ "cw-utils",
  "schemars",
  "serde",
 ]
 
 [[package]]
 name = "cw721-base"
-version = "0.13.4"
-source = "git+https://github.com/desmos-labs/cw-nfts?branch=paul/update-custom-msg-query#c1c57511c42655fc4a321a28652c15904d1e7ae0"
+version = "0.15.0"
+source = "git+https://github.com/desmos-labs/cw-nfts?branch=paul/update-custom-msg-query#2aaa2a0f013874cf7792396f731a128d6440adfb"
 dependencies = [
+ "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 0.13.4",
- "cw-utils 0.13.4",
- "cw2 0.13.4",
+ "cw-storage-plus 0.15.1",
+ "cw-utils",
+ "cw2 0.15.1",
  "cw721",
  "schemars",
  "serde",
@@ -343,8 +310,8 @@ dependencies = [
  "cosmwasm-std",
  "cosmwasm-storage",
  "cw-multi-test",
- "cw-storage-plus 0.15.0",
- "cw2 0.15.0",
+ "cw-storage-plus 0.15.1",
+ "cw2 0.15.1",
  "cw721",
  "cw721-base",
  "desmos-bindings",
@@ -417,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.3"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
 dependencies = [
  "block-buffer 0.10.3",
  "crypto-common",
@@ -434,9 +401,9 @@ checksum = "4f94fa09c2aeea5b8839e414b7b841bf429fd25b9c522116ac97ee87856d88b2"
 
 [[package]]
 name = "ecdsa"
-version = "0.14.6"
+version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6f2ba6c133e1d5390e2351b10b17aa43a41209c821c98efc4ec493d16a5a91"
+checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -452,7 +419,7 @@ checksum = "403ef3e961ab98f0ba902771d29f842058578bb1ce7e3c59dad5a6a93e784c69"
 dependencies = [
  "curve25519-dalek",
  "hex",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "serde",
  "sha2 0.9.9",
  "thiserror",
@@ -474,12 +441,12 @@ dependencies = [
  "base16ct",
  "crypto-bigint",
  "der",
- "digest 0.10.3",
+ "digest 0.10.5",
  "ff",
  "generic-array",
  "group",
  "pkcs8",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -491,7 +458,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df689201f395c6b90dfe87127685f8dbfc083a5e779e613575d8bd7314300c3e"
 dependencies = [
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -549,7 +516,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7391856def869c1c81063a03457c676fbcd419709c3dfb33d8d319de484b154d"
 dependencies = [
  "ff",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -565,7 +532,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.3",
+ "digest 0.10.5",
 ]
 
 [[package]]
@@ -580,9 +547,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8bf247779e67a9082a4790b45e71ac7cfd1321331a5c856a74a9faebdab78d0"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
@@ -595,21 +562,21 @@ checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "k256"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3636d281d46c3b64182eb3a0a42b7b483191a2ecc3f05301fa67403f7c9bc949"
+checksum = "72c1e0b51e7ec0a97369623508396067a486bd0cbed95a2659a4b863d28cfc8b"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "sha2 0.10.5",
+ "sha2 0.10.6",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.132"
+version = "0.2.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
 
 [[package]]
 name = "opaque-debug"
@@ -641,9 +608,9 @@ dependencies = [
  "cosmwasm-std",
  "cosmwasm-storage",
  "cw-multi-test",
- "cw-storage-plus 0.15.0",
- "cw-utils 0.15.0",
- "cw2 0.15.0",
+ "cw-storage-plus 0.15.1",
+ "cw-utils",
+ "cw2 0.15.1",
  "cw721",
  "cw721-base",
  "cw721-poap",
@@ -662,9 +629,9 @@ dependencies = [
  "cosmwasm-std",
  "cosmwasm-storage",
  "cw-multi-test",
- "cw-storage-plus 0.15.0",
- "cw-utils 0.15.0",
- "cw2 0.15.0",
+ "cw-storage-plus 0.15.1",
+ "cw-utils",
+ "cw2 0.15.1",
  "cw721",
  "cw721-base",
  "cw721-poap",
@@ -677,9 +644,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
 dependencies = [
  "unicode-ident",
 ]
@@ -727,9 +694,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.7",
 ]
@@ -742,9 +709,9 @@ dependencies = [
  "cosmwasm-std",
  "cosmwasm-storage",
  "cw-multi-test",
- "cw-storage-plus 0.15.0",
- "cw-utils 0.15.0",
- "cw2 0.15.0",
+ "cw-storage-plus 0.15.1",
+ "cw-utils",
+ "cw2 0.15.1",
  "cw721",
  "cw721-base",
  "cw721-remarkables",
@@ -774,9 +741,9 @@ checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
 name = "schemars"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1847b767a3d62d95cbf3d8a9f0e421cf57a0d8aa4f411d4b16525afb0284d4ed"
+checksum = "2a5fb6c61f29e723026dc8e923d94c694313212abbecbbe5f55a7748eec5b307"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
@@ -786,9 +753,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af4d7e1b012cb3d9129567661a63755ea4b8a7386d339dc945ae187e403c6743"
+checksum = "f188d036977451159430f3b8dc82ec76364a42b7e289c2b18a9a18f4470058e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -882,23 +849,23 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9db03534dff993187064c4e0c05a5708d2a9728ace9a8959b77bedf415dac5"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.3",
+ "digest 0.10.5",
 ]
 
 [[package]]
 name = "signature"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90531723b08e4d6d71b791108faf51f03e1b4a7784f96b2b87f852ebc247228"
+checksum = "deb766570a2825fa972bceff0d195727876a9cdf2460ab2e52d455dc2de47fd9"
 dependencies = [
- "digest 0.10.3",
- "rand_core 0.6.3",
+ "digest 0.10.5",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -925,9 +892,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.99"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -936,18 +903,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.35"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c53f98874615aea268107765aa1ed8f6116782501d18e53d08b471733bea6c85"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.35"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8b463991b4eab2d801e724172285ec4195c650e8ec79b149e6c2a8e6dd3f783"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -977,9 +944,9 @@ dependencies = [
  "cosmwasm-std",
  "cosmwasm-storage",
  "cw-multi-test",
- "cw-storage-plus 0.15.0",
- "cw-utils 0.15.0",
- "cw2 0.15.0",
+ "cw-storage-plus 0.15.1",
+ "cw-utils",
+ "cw2 0.15.1",
  "desmos-bindings",
  "schemars",
  "serde",
@@ -994,9 +961,9 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "uint"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f03af7ccf01dd611cc450a0d10dbc9b745770d096473e2faf0ca6e2d66d1e0"
+checksum = "a45526d29728d135c2900b0d30573fe3ee79fceb12ef534c7bb30e810a91b601"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -1018,9 +985,9 @@ checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,9 +394,9 @@ dependencies = [
 
 [[package]]
 name = "desmos-bindings"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ba3e792552d6960b0205994a4fca5e83daffb12b93f7ca9ac86c99d703b805"
+checksum = "6a1cbb24dd731c22d21b49690a6ab257e89435c124ea1d0f354295e21d3ffc49"
 dependencies = [
  "anyhow",
  "cosmwasm-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,20 +259,6 @@ dependencies = [
 
 [[package]]
 name = "cw-utils"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414b91f3d7a619bb26c835119d7095804596a1382ddc1d184c33c1d2c17f6c5e"
-dependencies = [
- "cosmwasm-std",
- "cw2 0.14.0",
- "schemars",
- "semver",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "cw-utils"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a67007ff056f4cd034f361c8ed69780c0180959b9c8037c84f3caa78120faf5"
@@ -991,9 +977,9 @@ dependencies = [
  "cosmwasm-std",
  "cosmwasm-storage",
  "cw-multi-test",
- "cw-storage-plus 0.14.0",
- "cw-utils 0.14.0",
- "cw2 0.14.0",
+ "cw-storage-plus 0.15.0",
+ "cw-utils 0.15.0",
+ "cw2 0.15.0",
  "desmos-bindings",
  "schemars",
  "serde",

--- a/contracts/cw721-poap/Cargo.toml
+++ b/contracts/cw721-poap/Cargo.toml
@@ -41,7 +41,7 @@ cw721-base = { git = "https://github.com/desmos-labs/cw-nfts", features = ["libr
 
 [dev-dependencies]
 cosmwasm-schema = "1.1.2"
-cw-multi-test = "0.13.2"
+cw-multi-test = "0.15.0"
 desmos-bindings = { version = "1.1.0", default-features = false, features = ["mocks"]}
 cw721 = { git = "https://github.com/desmos-labs/cw-nfts", branch = "paul/update-custom-msg-query" }
 

--- a/contracts/cw721-poap/Cargo.toml
+++ b/contracts/cw721-poap/Cargo.toml
@@ -41,7 +41,7 @@ cw721-base = { git = "https://github.com/desmos-labs/cw-nfts", features = ["libr
 
 [dev-dependencies]
 cosmwasm-schema = "1.1.2"
-cw-multi-test = "0.15.0"
+cw-multi-test = "0.13.2"
 desmos-bindings = { version = "1.1.0", default-features = false, features = ["mocks"]}
 cw721 = { git = "https://github.com/desmos-labs/cw-nfts", branch = "paul/update-custom-msg-query" }
 

--- a/contracts/cw721-poap/Cargo.toml
+++ b/contracts/cw721-poap/Cargo.toml
@@ -36,13 +36,13 @@ cw2 = "0.15.0"
 schemars = "0.8.8"
 serde = { version = "1.0.145", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.35" }
-desmos-bindings = { version = "1.1.0", default-features = false, features = ["msg", "query"] }
+desmos-bindings = { version = "1.1.1", default-features = false, features = ["msg", "query"] }
 cw721-base = { git = "https://github.com/desmos-labs/cw-nfts", features = ["library"], branch = "paul/update-custom-msg-query" }
 
 [dev-dependencies]
 cosmwasm-schema = "1.1.2"
 cw-multi-test = "0.15.0"
-desmos-bindings = { version = "1.1.0", default-features = false, features = ["mocks"]}
+desmos-bindings = { version = "1.1.1", default-features = false, features = ["mocks"]}
 cw721 = { git = "https://github.com/desmos-labs/cw-nfts", branch = "paul/update-custom-msg-query" }
 
 

--- a/contracts/cw721-poap/Cargo.toml
+++ b/contracts/cw721-poap/Cargo.toml
@@ -36,13 +36,13 @@ cw2 = "0.15.0"
 schemars = "0.8.8"
 serde = { version = "1.0.145", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.35" }
-desmos-bindings = { version = "1.0.0", default-features = false, features = ["msg", "query"] }
+desmos-bindings = { version = "1.1.0", default-features = false, features = ["msg", "query"] }
 cw721-base = { git = "https://github.com/desmos-labs/cw-nfts", features = ["library"], branch = "paul/update-custom-msg-query" }
 
 [dev-dependencies]
 cosmwasm-schema = "1.1.2"
 cw-multi-test = "0.13.2"
-desmos-bindings = { version = "1.0.3", default-features = false, features = ["mocks"]}
+desmos-bindings = { version = "1.1.0", default-features = false, features = ["mocks"]}
 cw721 = { git = "https://github.com/desmos-labs/cw-nfts", branch = "paul/update-custom-msg-query" }
 
 

--- a/contracts/cw721-poap/src/lib.rs
+++ b/contracts/cw721-poap/src/lib.rs
@@ -63,13 +63,13 @@ mod tests {
     use super::*;
     use cosmwasm_std::testing::{mock_env, mock_info};
     use cw721::Cw721Query;
-    use desmos_bindings::mocks::mock_queriers::mock_dependencies_with_custom_querier;
+    use desmos_bindings::mocks::mock_queriers::mock_desmos_dependencies;
 
     const CREATOR: &str = "creator";
 
     #[test]
     fn use_metadata_extension() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let contract = Cw721MetadataContract::default();
 
         let info = mock_info(CREATOR, &[]);

--- a/contracts/cw721-remarkables/Cargo.toml
+++ b/contracts/cw721-remarkables/Cargo.toml
@@ -41,7 +41,7 @@ cw721-base = { git = "https://github.com/desmos-labs/cw-nfts", features = ["libr
 
 [dev-dependencies]
 cosmwasm-schema = "1.1.0"
-cw-multi-test = "0.15.0"
+cw-multi-test = "0.13.2"
 desmos-bindings = { version = "1.1.0", default-features = false, features = ["mocks"]}
 cw721 = { git = "https://github.com/desmos-labs/cw-nfts", branch = "paul/update-custom-msg-query" }
 

--- a/contracts/cw721-remarkables/Cargo.toml
+++ b/contracts/cw721-remarkables/Cargo.toml
@@ -36,13 +36,13 @@ cw2 = "0.14.0"
 schemars = "0.8.8"
 serde = { version = "1.0.145", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.35" }
-desmos-bindings = { version = "1.1.0", default-features = false, features = ["msg", "query"] }
+desmos-bindings = { version = "1.1.1", default-features = false, features = ["msg", "query"] }
 cw721-base = { git = "https://github.com/desmos-labs/cw-nfts", features = ["library"], branch = "paul/update-custom-msg-query" }
 
 [dev-dependencies]
 cosmwasm-schema = "1.1.0"
 cw-multi-test = "0.15.0"
-desmos-bindings = { version = "1.1.0", default-features = false, features = ["mocks"]}
+desmos-bindings = { version = "1.1.1", default-features = false, features = ["mocks"]}
 cw721 = { git = "https://github.com/desmos-labs/cw-nfts", branch = "paul/update-custom-msg-query" }
 
 

--- a/contracts/cw721-remarkables/Cargo.toml
+++ b/contracts/cw721-remarkables/Cargo.toml
@@ -41,7 +41,7 @@ cw721-base = { git = "https://github.com/desmos-labs/cw-nfts", features = ["libr
 
 [dev-dependencies]
 cosmwasm-schema = "1.1.0"
-cw-multi-test = "0.13.2"
+cw-multi-test = "0.15.0"
 desmos-bindings = { version = "1.1.0", default-features = false, features = ["mocks"]}
 cw721 = { git = "https://github.com/desmos-labs/cw-nfts", branch = "paul/update-custom-msg-query" }
 

--- a/contracts/cw721-remarkables/Cargo.toml
+++ b/contracts/cw721-remarkables/Cargo.toml
@@ -36,13 +36,13 @@ cw2 = "0.14.0"
 schemars = "0.8.8"
 serde = { version = "1.0.145", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.35" }
-desmos-bindings = { version = "1.0.0", default-features = false, features = ["msg", "query"] }
+desmos-bindings = { version = "1.1.0", default-features = false, features = ["msg", "query"] }
 cw721-base = { git = "https://github.com/desmos-labs/cw-nfts", features = ["library"], branch = "paul/update-custom-msg-query" }
 
 [dev-dependencies]
 cosmwasm-schema = "1.1.0"
 cw-multi-test = "0.13.2"
-desmos-bindings = { version = "1.0.3", default-features = false, features = ["mocks"]}
+desmos-bindings = { version = "1.1.0", default-features = false, features = ["mocks"]}
 cw721 = { git = "https://github.com/desmos-labs/cw-nfts", branch = "paul/update-custom-msg-query" }
 
 

--- a/contracts/cw721-remarkables/src/lib.rs
+++ b/contracts/cw721-remarkables/src/lib.rs
@@ -65,13 +65,13 @@ mod tests {
     use super::*;
     use cosmwasm_std::testing::{mock_env, mock_info};
     use cw721::Cw721Query;
-    use desmos_bindings::mocks::mock_queriers::mock_dependencies_with_custom_querier;
+    use desmos_bindings::mocks::mock_queriers::mock_desmos_dependencies;
 
     const CREATOR: &str = "creator";
 
     #[test]
     fn use_metadata_extension() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let contract = Cw721MetadataContract::default();
 
         let info = mock_info(CREATOR, &[]);

--- a/contracts/poap-manager/Cargo.toml
+++ b/contracts/poap-manager/Cargo.toml
@@ -36,7 +36,7 @@ cw2 = "0.15.0"
 schemars = "0.8.8"
 serde = { version = "1.0.145", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.35" }
-desmos-bindings = { version = "1.1.0", default-features = false, features = ["profiles", "query", "msg"]}
+desmos-bindings = { version = "1.1.1", default-features = false, features = ["profiles", "query", "msg"]}
 poap = { path = "../poap", version = "0.1.0", features = ["library"]}
 cw721-base = { git = "https://github.com/desmos-labs/cw-nfts", features = ["library"], branch = "paul/update-custom-msg-query" }
 cw-utils = "0.15.0"
@@ -46,5 +46,5 @@ cw721-poap = { path = "../cw721-poap", version = "0.1.0", features = ["library"]
 cosmwasm-schema = "1.1.2"
 cw-multi-test = "0.15.0"
 cw721 = { git = "https://github.com/desmos-labs/cw-nfts", branch = "paul/update-custom-msg-query" }
-desmos-bindings = { version = "1.1.0", default-features = false, features = ["mocks"]}
+desmos-bindings = { version = "1.1.1", default-features = false, features = ["mocks"]}
 

--- a/contracts/poap-manager/Cargo.toml
+++ b/contracts/poap-manager/Cargo.toml
@@ -36,7 +36,7 @@ cw2 = "0.15.0"
 schemars = "0.8.8"
 serde = { version = "1.0.145", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.35" }
-desmos-bindings = { version = "1.0.3", default-features = false, features = ["profiles", "query", "msg"]}
+desmos-bindings = { version = "1.1.0", default-features = false, features = ["profiles", "query", "msg"]}
 poap = { path = "../poap", version = "0.1.0", features = ["library"]}
 cw721-base = { git = "https://github.com/desmos-labs/cw-nfts", features = ["library"], branch = "paul/update-custom-msg-query" }
 cw-utils = "0.15.0"
@@ -46,5 +46,5 @@ cw721-poap = { path = "../cw721-poap", version = "0.1.0", features = ["library"]
 cosmwasm-schema = "1.1.2"
 cw-multi-test = { version = "0.13.4" }
 cw721 = { git = "https://github.com/desmos-labs/cw-nfts", branch = "paul/update-custom-msg-query" }
-desmos-bindings = { version = "1.0.3", default-features = false, features = ["mocks"]}
+desmos-bindings = { version = "1.1.0", default-features = false, features = ["mocks"]}
 

--- a/contracts/poap-manager/Cargo.toml
+++ b/contracts/poap-manager/Cargo.toml
@@ -44,7 +44,7 @@ cw721-poap = { path = "../cw721-poap", version = "0.1.0", features = ["library"]
 
 [dev-dependencies]
 cosmwasm-schema = "1.1.2"
-cw-multi-test = { version = "0.13.4" }
+cw-multi-test = "0.15.0"
 cw721 = { git = "https://github.com/desmos-labs/cw-nfts", branch = "paul/update-custom-msg-query" }
 desmos-bindings = { version = "1.1.0", default-features = false, features = ["mocks"]}
 

--- a/contracts/poap-manager/src/contract.rs
+++ b/contracts/poap-manager/src/contract.rs
@@ -195,7 +195,7 @@ mod tests {
     use cosmwasm_std::{StdError, SubMsgResponse, SubMsgResult, Timestamp};
     use cw721_base::InstantiateMsg as Cw721InstantiateMsg;
     use cw_utils::ParseReplyError;
-    use desmos_bindings::mocks::mock_queriers::mock_dependencies_with_custom_querier;
+    use desmos_bindings::mocks::mock_queriers::mock_desmos_dependencies;
     use poap::msg::{EventInfo, InstantiateMsg as POAPInstantiateMsg};
 
     const CREATOR: &str = "desmos1nwp8gxrnmrsrzjdhvk47vvmthzxjtphgxp5ftc";
@@ -234,7 +234,7 @@ mod tests {
 
     #[test]
     fn instatiate_with_invalid_msg_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let env = mock_env();
         let info = mock_info(CREATOR, &vec![]);
         let invalid_msg = InstantiateMsg {
@@ -266,7 +266,7 @@ mod tests {
 
     #[test]
     fn instatiate_with_invalid_admin_address_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let env = mock_env();
         let info = mock_info(CREATOR, &vec![]);
         let invalid_msg = InstantiateMsg {
@@ -300,7 +300,7 @@ mod tests {
 
     #[test]
     fn instatiate_properly() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         do_instantiate(deps.as_mut());
 
         let config = CONFIG.load(&deps.storage).unwrap();
@@ -313,7 +313,7 @@ mod tests {
 
     #[test]
     fn poap_instantiate_with_invalid_reply_id_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         do_instantiate(deps.as_mut());
         let env = mock_env();
         let result = reply(
@@ -332,7 +332,7 @@ mod tests {
 
     #[test]
     fn poap_instantiate_with_invalid_instantiate_msg_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         do_instantiate(deps.as_mut());
         let env = mock_env();
         let result = reply(
@@ -356,7 +356,7 @@ mod tests {
 
     #[test]
     fn claim_with_unsupported_desmos_deps_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         do_instantiate(deps.as_mut());
         let env = mock_env();
         let info = mock_info(CREATOR, &vec![]);
@@ -369,7 +369,7 @@ mod tests {
 
     #[test]
     fn claim_properly() {
-        let mut deps = mock_dependencies_with_custom_querier(&vec![]);
+        let mut deps = mock_desmos_dependencies();
         do_instantiate(deps.as_mut());
         POAP_CONTRACT_ADDRESS
             .save(deps.as_mut().storage, &Addr::unchecked(""))
@@ -382,7 +382,7 @@ mod tests {
 
     #[test]
     fn mint_to_with_invalid_recipient_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         do_instantiate(deps.as_mut());
         POAP_CONTRACT_ADDRESS
             .save(deps.as_mut().storage, &Addr::unchecked(""))
@@ -402,7 +402,7 @@ mod tests {
 
     #[test]
     fn mint_to_properly() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         do_instantiate(deps.as_mut());
         POAP_CONTRACT_ADDRESS
             .save(deps.as_mut().storage, &Addr::unchecked(""))
@@ -417,7 +417,7 @@ mod tests {
 
     #[test]
     fn update_admin_with_invalid_new_admin_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         do_instantiate(deps.as_mut());
         let env = mock_env();
         let info = mock_info(CREATOR, &vec![]);
@@ -434,7 +434,7 @@ mod tests {
 
     #[test]
     fn update_admin_without_permission_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         do_instantiate(deps.as_mut());
         let env = mock_env();
         let info = mock_info(NEW_ADMIN, &vec![]);
@@ -451,7 +451,7 @@ mod tests {
 
     #[test]
     fn update_admin_with_invalid_address_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         do_instantiate(deps.as_mut());
         let env = mock_env();
         let info = mock_info(CREATOR, &vec![]);
@@ -468,7 +468,7 @@ mod tests {
 
     #[test]
     fn update_admin_properly() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         do_instantiate(deps.as_mut());
         let env = mock_env();
         let info = mock_info(CREATOR, &vec![]);

--- a/contracts/poap/Cargo.toml
+++ b/contracts/poap/Cargo.toml
@@ -45,6 +45,6 @@ cw721 = { git = "https://github.com/desmos-labs/cw-nfts", branch = "paul/update-
 
 [dev-dependencies]
 cosmwasm-schema = "1.1.2"
-cw-multi-test = "0.15.0"
+cw-multi-test = { version = "0.13.4" }
 desmos-bindings = { version = "1.1.0", default-features = false, features = ["mocks"]}
 

--- a/contracts/poap/Cargo.toml
+++ b/contracts/poap/Cargo.toml
@@ -45,6 +45,6 @@ cw721 = { git = "https://github.com/desmos-labs/cw-nfts", branch = "paul/update-
 
 [dev-dependencies]
 cosmwasm-schema = "1.1.2"
-cw-multi-test = { version = "0.13.4" }
+cw-multi-test = "0.15.0"
 desmos-bindings = { version = "1.1.0", default-features = false, features = ["mocks"]}
 

--- a/contracts/poap/Cargo.toml
+++ b/contracts/poap/Cargo.toml
@@ -37,7 +37,7 @@ cw-utils = "0.15.0"
 schemars = "0.8.8"
 serde = { version = "1.0.145", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.35" }
-desmos-bindings = { version = "1.1.0", default-features = false, features = ["query", "msg"]}
+desmos-bindings = { version = "1.1.1", default-features = false, features = ["query", "msg"]}
 cw721-base = { git = "https://github.com/desmos-labs/cw-nfts", features = ["library"], branch = "paul/update-custom-msg-query" }
 url = "2.3.1"
 cw721-poap = { path = "../cw721-poap", version = "0.1.0", features = ["library"]}
@@ -46,5 +46,5 @@ cw721 = { git = "https://github.com/desmos-labs/cw-nfts", branch = "paul/update-
 [dev-dependencies]
 cosmwasm-schema = "1.1.2"
 cw-multi-test = "0.15.0"
-desmos-bindings = { version = "1.1.0", default-features = false, features = ["mocks"]}
+desmos-bindings = { version = "1.1.1", default-features = false, features = ["mocks"]}
 

--- a/contracts/poap/Cargo.toml
+++ b/contracts/poap/Cargo.toml
@@ -37,7 +37,7 @@ cw-utils = "0.15.0"
 schemars = "0.8.8"
 serde = { version = "1.0.145", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.35" }
-desmos-bindings = { version = "1.0.3", default-features = false, features = ["query", "msg"]}
+desmos-bindings = { version = "1.1.0", default-features = false, features = ["query", "msg"]}
 cw721-base = { git = "https://github.com/desmos-labs/cw-nfts", features = ["library"], branch = "paul/update-custom-msg-query" }
 url = "2.3.1"
 cw721-poap = { path = "../cw721-poap", version = "0.1.0", features = ["library"]}
@@ -46,5 +46,5 @@ cw721 = { git = "https://github.com/desmos-labs/cw-nfts", branch = "paul/update-
 [dev-dependencies]
 cosmwasm-schema = "1.1.2"
 cw-multi-test = { version = "0.13.4" }
-desmos-bindings = { version = "1.0.3", default-features = false, features = ["mocks"]}
+desmos-bindings = { version = "1.1.0", default-features = false, features = ["mocks"]}
 

--- a/contracts/poap/src/contract.rs
+++ b/contracts/poap/src/contract.rs
@@ -480,7 +480,7 @@ mod tests {
     use crate::ContractError::Unauthorized;
     use cosmwasm_std::testing::{mock_env, mock_info};
     use cosmwasm_std::{DepsMut, Timestamp};
-    use desmos_bindings::mocks::mock_queriers::mock_dependencies_with_custom_querier;
+    use desmos_bindings::mocks::mock_queriers::mock_desmos_dependencies;
 
     const CREATOR: &str = "creator";
     const ADMIN: &str = "admin";
@@ -506,7 +506,7 @@ mod tests {
 
     #[test]
     fn instantiate_with_invalid_admin_addr_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let env = mock_env();
         let info = mock_info(ADMIN, &vec![]);
 
@@ -519,7 +519,7 @@ mod tests {
 
     #[test]
     fn instantiate_with_invalid_minter_addr_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let env = mock_env();
         let info = mock_info(ADMIN, &vec![]);
 
@@ -532,7 +532,7 @@ mod tests {
 
     #[test]
     fn instantiate_with_invalid_creator_addr_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let env = mock_env();
         let info = mock_info(ADMIN, &vec![]);
 
@@ -545,7 +545,7 @@ mod tests {
 
     #[test]
     fn instantiate_with_event_start_before_current_time_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let env = mock_env();
         let info = mock_info(ADMIN, &vec![]);
 
@@ -567,7 +567,7 @@ mod tests {
 
     #[test]
     fn instantiate_with_event_start_equal_current_time_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let env = mock_env();
         let info = mock_info(ADMIN, &vec![]);
         let mut init_msg = get_valid_init_msg(1);
@@ -588,7 +588,7 @@ mod tests {
 
     #[test]
     fn instantiate_with_event_end_before_current_time_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let env = mock_env();
         let info = mock_info(ADMIN, &vec![]);
         let mut init_msg = get_valid_init_msg(1);
@@ -612,7 +612,7 @@ mod tests {
 
     #[test]
     fn instantiate_with_event_end_equal_current_time_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let env = mock_env();
         let info = mock_info(ADMIN, &vec![]);
         let mut init_msg = get_valid_init_msg(1);
@@ -634,7 +634,7 @@ mod tests {
 
     #[test]
     fn instantiate_with_event_start_after_end_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let env = mock_env();
         let info = mock_info(ADMIN, &vec![]);
         let mut init_msg = get_valid_init_msg(1);
@@ -658,7 +658,7 @@ mod tests {
 
     #[test]
     fn instantiate_with_event_start_equal_end_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let env = mock_env();
         let info = mock_info(ADMIN, &vec![]);
         let mut init_msg = get_valid_init_msg(1);
@@ -680,7 +680,7 @@ mod tests {
 
     #[test]
     fn instantiate_with_invalid_poap_uri_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let env = mock_env();
         let info = mock_info(ADMIN, &vec![]);
         let mut init_msg = get_valid_init_msg(1);
@@ -694,7 +694,7 @@ mod tests {
 
     #[test]
     fn instantiate_with_non_ipfs_poap_uri_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let env = mock_env();
         let info = mock_info(ADMIN, &vec![]);
         let mut init_msg = get_valid_init_msg(1);
@@ -707,7 +707,7 @@ mod tests {
 
     #[test]
     fn enable_mint_properly() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let env = mock_env();
         let info = mock_info(ADMIN, &vec![]);
 
@@ -722,7 +722,7 @@ mod tests {
 
     #[test]
     fn enable_mint_without_permission_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let env = mock_env();
         let info = mock_info(USER, &vec![]);
 
@@ -735,7 +735,7 @@ mod tests {
 
     #[test]
     fn disable_mint_properly() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let env = mock_env();
         let info = mock_info(ADMIN, &vec![]);
 
@@ -750,7 +750,7 @@ mod tests {
 
     #[test]
     fn normal_user_can_not_disable_mint_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let env = mock_env();
         let info = mock_info(USER, &vec![]);
 
@@ -763,7 +763,7 @@ mod tests {
 
     #[test]
     fn creator_change_event_info_properly() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let mut env = mock_env();
         let info = mock_info(CREATOR, &vec![]);
         let new_start_time = Timestamp::from_seconds(env.block.time.seconds() + 100);
@@ -787,7 +787,7 @@ mod tests {
 
     #[test]
     fn non_creator_change_event_info_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let env = mock_env();
         let info = mock_info(USER, &vec![]);
         let new_start_time = Timestamp::from_seconds(env.block.time.seconds() + 100);
@@ -813,7 +813,7 @@ mod tests {
 
     #[test]
     fn event_info_update_after_event_started_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let mut env = mock_env();
         let info = mock_info(CREATOR, &vec![]);
 
@@ -851,7 +851,7 @@ mod tests {
 
     #[test]
     fn event_info_update_after_event_terminated_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let mut env = mock_env();
         let info = mock_info(CREATOR, &vec![]);
 
@@ -890,7 +890,7 @@ mod tests {
 
     #[test]
     fn event_info_update_properly() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let mut env = mock_env();
         let info = mock_info(CREATOR, &vec![]);
 
@@ -909,7 +909,7 @@ mod tests {
 
     #[test]
     fn event_info_start_time_equal_end_time_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let mut env = mock_env();
         let info = mock_info(CREATOR, &vec![]);
 
@@ -934,7 +934,7 @@ mod tests {
 
     #[test]
     fn event_info_start_time_after_end_time_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let mut env = mock_env();
         let info = mock_info(CREATOR, &vec![]);
 
@@ -958,7 +958,7 @@ mod tests {
 
     #[test]
     fn event_info_start_time_before_current_time_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let mut env = mock_env();
         let info = mock_info(CREATOR, &vec![]);
 
@@ -982,7 +982,7 @@ mod tests {
 
     #[test]
     fn event_info_start_time_equal_current_time_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let mut env = mock_env();
         let info = mock_info(CREATOR, &vec![]);
 
@@ -1006,7 +1006,7 @@ mod tests {
 
     #[test]
     fn event_info_end_time_before_current_time_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let mut env = mock_env();
         let info = mock_info(CREATOR, &vec![]);
 
@@ -1030,7 +1030,7 @@ mod tests {
 
     #[test]
     fn event_info_end_time_equal_current_time_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let mut env = mock_env();
         let info = mock_info(CREATOR, &vec![]);
 
@@ -1054,7 +1054,7 @@ mod tests {
 
     #[test]
     fn update_admin_without_permission_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let env = mock_env();
         const NEW_ADMIN: &str = "admin2";
 
@@ -1083,7 +1083,7 @@ mod tests {
 
     #[test]
     fn update_admin_with_permission_properly() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let env = mock_env();
         const NEW_ADMIN: &str = "admin2";
 
@@ -1101,7 +1101,7 @@ mod tests {
 
     #[test]
     fn update_minter_permission_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let env = mock_env();
         const NEW_MINTER: &str = "minter2";
 
@@ -1133,7 +1133,7 @@ mod tests {
 
     #[test]
     fn update_minter_with_permission_properly() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let env = mock_env();
         const NEW_MINTER: &str = "minter2";
 
@@ -1151,7 +1151,7 @@ mod tests {
 
     #[test]
     fn mint_with_event_not_started_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let mut env = mock_env();
         let info = mock_info(ADMIN, &vec![]);
 
@@ -1179,7 +1179,7 @@ mod tests {
 
     #[test]
     fn mint_with_event_terminated_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let mut env = mock_env();
         let info = mock_info(ADMIN, &vec![]);
 
@@ -1207,7 +1207,7 @@ mod tests {
 
     #[test]
     fn mint_without_permissions_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let mut env = mock_env();
         let info = mock_info(USER, &vec![]);
 
@@ -1225,7 +1225,7 @@ mod tests {
 
     #[test]
     fn mint_out_of_max_amount_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let mut env = mock_env();
         let info = mock_info(ADMIN, &vec![]);
 
@@ -1288,7 +1288,7 @@ mod tests {
 
     #[test]
     fn mint_to_out_of_max_amount_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let mut env = mock_env();
         let info = mock_info(ADMIN, &vec![]);
 
@@ -1355,7 +1355,7 @@ mod tests {
 
     #[test]
     fn mint_to_without_permission_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let mut env = mock_env();
 
         do_instantiate(deps.as_mut());
@@ -1377,7 +1377,7 @@ mod tests {
 
     #[test]
     fn mint_to_from_minter_properly() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let mut env = mock_env();
 
         do_instantiate(deps.as_mut());
@@ -1399,7 +1399,7 @@ mod tests {
 
     #[test]
     fn mint_to_from_admin_properly() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
         let mut env = mock_env();
 
         do_instantiate(deps.as_mut());

--- a/contracts/remarkables/Cargo.toml
+++ b/contracts/remarkables/Cargo.toml
@@ -31,19 +31,19 @@ optimize = """docker run --rm -v "$(pwd)"/../..:/code \
 [dependencies]
 cosmwasm-std = "1.0.0"
 cosmwasm-storage = "1.0.0"
-cw-storage-plus = { version = "0.13.2", features = ["iterator"]}
-cw2 = "0.13.2"
+cw-storage-plus = { version = "0.15.0"}
+cw2 = "0.15.0"
 schemars = "0.8.8"
 serde = { version = "1.0.145", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.31" }
 desmos-bindings = { version = "1.1.0", default-features = false, features = ["query", "msg", "reactions", "posts", "subspaces"] }
 cw721-base = { git = "https://github.com/desmos-labs/cw-nfts", features = ["library"], branch = "paul/update-custom-msg-query" }
-cw-utils = "0.14.0"
+cw-utils = "0.15.0"
 cw721 = { git = "https://github.com/desmos-labs/cw-nfts", branch = "paul/update-custom-msg-query" }
 url = "2.3.1"
 cw721-remarkables = { path = "../cw721-remarkables", version = "0.1.0", features = ["library"]}
 
 [dev-dependencies]
 cosmwasm-schema = "1.0.0"
-cw-multi-test = "0.13.2"
+cw-multi-test = "0.15.0"
 desmos-bindings = { version = "1.1.0", default-features = false, features = ["mocks"] }

--- a/contracts/remarkables/Cargo.toml
+++ b/contracts/remarkables/Cargo.toml
@@ -36,7 +36,7 @@ cw2 = "0.15.0"
 schemars = "0.8.8"
 serde = { version = "1.0.145", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.31" }
-desmos-bindings = { version = "1.1.0", default-features = false, features = ["query", "msg", "reactions", "posts", "subspaces"] }
+desmos-bindings = { version = "1.1.1", default-features = false, features = ["query", "msg", "reactions", "posts", "subspaces"] }
 cw721-base = { git = "https://github.com/desmos-labs/cw-nfts", features = ["library"], branch = "paul/update-custom-msg-query" }
 cw-utils = "0.15.0"
 cw721 = { git = "https://github.com/desmos-labs/cw-nfts", branch = "paul/update-custom-msg-query" }
@@ -46,4 +46,4 @@ cw721-remarkables = { path = "../cw721-remarkables", version = "0.1.0", features
 [dev-dependencies]
 cosmwasm-schema = "1.0.0"
 cw-multi-test = "0.15.0"
-desmos-bindings = { version = "1.1.0", default-features = false, features = ["mocks"] }
+desmos-bindings = { version = "1.1.1", default-features = false, features = ["mocks"] }

--- a/contracts/remarkables/Cargo.toml
+++ b/contracts/remarkables/Cargo.toml
@@ -45,5 +45,5 @@ cw721-remarkables = { path = "../cw721-remarkables", version = "0.1.0", features
 
 [dev-dependencies]
 cosmwasm-schema = "1.0.0"
-cw-multi-test = "0.15.0"
+cw-multi-test = "0.13.2"
 desmos-bindings = { version = "1.1.0", default-features = false, features = ["mocks"] }

--- a/contracts/remarkables/Cargo.toml
+++ b/contracts/remarkables/Cargo.toml
@@ -45,5 +45,5 @@ cw721-remarkables = { path = "../cw721-remarkables", version = "0.1.0", features
 
 [dev-dependencies]
 cosmwasm-schema = "1.0.0"
-cw-multi-test = "0.13.2"
+cw-multi-test = "0.15.0"
 desmos-bindings = { version = "1.1.0", default-features = false, features = ["mocks"] }

--- a/contracts/remarkables/Cargo.toml
+++ b/contracts/remarkables/Cargo.toml
@@ -36,7 +36,7 @@ cw2 = "0.13.2"
 schemars = "0.8.8"
 serde = { version = "1.0.145", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.31" }
-desmos-bindings = { version = "1.0.3", default-features = false, features = ["query", "msg", "reactions", "posts", "subspaces"] }
+desmos-bindings = { version = "1.1.0", default-features = false, features = ["query", "msg", "reactions", "posts", "subspaces"] }
 cw721-base = { git = "https://github.com/desmos-labs/cw-nfts", features = ["library"], branch = "paul/update-custom-msg-query" }
 cw-utils = "0.14.0"
 cw721 = { git = "https://github.com/desmos-labs/cw-nfts", branch = "paul/update-custom-msg-query" }
@@ -46,4 +46,4 @@ cw721-remarkables = { path = "../cw721-remarkables", version = "0.1.0", features
 [dev-dependencies]
 cosmwasm-schema = "1.0.0"
 cw-multi-test = "0.13.2"
-desmos-bindings = { version = "1.0.3", default-features = false, features = ["mocks"] }
+desmos-bindings = { version = "1.1.0", default-features = false, features = ["mocks"] }

--- a/contracts/remarkables/src/contract.rs
+++ b/contracts/remarkables/src/contract.rs
@@ -414,7 +414,7 @@ mod tests {
         SubMsgResult, SystemError, SystemResult,
     };
     use cw721_base::InstantiateMsg as Cw721InstantiateMsg;
-    use desmos_bindings::mocks::mock_queriers::mock_dependencies_with_custom_querier;
+    use desmos_bindings::mocks::mock_queriers::mock_desmos_dependencies;
     use desmos_bindings::{
         posts::{mocks::mock_posts_query_response, query::PostsQuery},
         reactions::{
@@ -466,7 +466,7 @@ mod tests {
         use super::*;
         #[test]
         fn instatiate_with_invalid_admin_address_error() {
-            let mut deps = mock_dependencies_with_custom_querier(&[]);
+            let mut deps = mock_desmos_dependencies();
             let env = mock_env();
             let info = mock_info(ADMIN, &vec![]);
             let mut invalid_msg = get_valid_instantiate_msg();
@@ -510,7 +510,7 @@ mod tests {
         }
         #[test]
         fn instatiate_without_permission_error() {
-            let mut deps = mock_dependencies_with_custom_querier(&[]);
+            let mut deps = mock_desmos_dependencies();
             let env = mock_env();
             let info = mock_info(NEW_ADMIN, &vec![]);
             let mut invalid_msg = get_valid_instantiate_msg();
@@ -524,7 +524,7 @@ mod tests {
         }
         #[test]
         fn instatiate_properly() {
-            let mut deps = mock_dependencies_with_custom_querier(&[]);
+            let mut deps = mock_desmos_dependencies();
             do_instantiate(deps.as_mut());
             let config = CONFIG.load(&deps.storage).unwrap();
             let expected_config = ConfigState {
@@ -543,7 +543,7 @@ mod tests {
         use super::*;
         #[test]
         fn cw721_instantiate_with_invalid_reply_id_error() {
-            let mut deps = mock_dependencies_with_custom_querier(&[]);
+            let mut deps = mock_desmos_dependencies();
             do_instantiate(deps.as_mut());
             let env = mock_env();
             let result = reply(
@@ -561,7 +561,7 @@ mod tests {
         }
         #[test]
         fn cw721_instantiate_with_invalid_instantiate_msg_error() {
-            let mut deps = mock_dependencies_with_custom_querier(&[]);
+            let mut deps = mock_desmos_dependencies();
             do_instantiate(deps.as_mut());
             let env = mock_env();
             let result = reply(
@@ -582,7 +582,7 @@ mod tests {
         use super::*;
         #[test]
         fn mint_with_not_existing_rarity_error() {
-            let mut deps = mock_dependencies_with_custom_querier(&[]);
+            let mut deps = mock_desmos_dependencies();
             do_instantiate(deps.as_mut());
             let env = mock_env();
             let info = mock_info(USER, &vec![]);
@@ -598,7 +598,7 @@ mod tests {
         }
         #[test]
         fn mint_with_empty_fees_error() {
-            let mut deps = mock_dependencies_with_custom_querier(&[]);
+            let mut deps = mock_desmos_dependencies();
             do_instantiate(deps.as_mut());
             let env = mock_env();
             let info = mock_info(USER, &vec![]);
@@ -614,7 +614,7 @@ mod tests {
         }
         #[test]
         fn mint_with_other_denom_fees_error() {
-            let mut deps = mock_dependencies_with_custom_querier(&[]);
+            let mut deps = mock_desmos_dependencies();
             do_instantiate(deps.as_mut());
             let env = mock_env();
             let info = mock_info(USER, &coins(100, "other"));
@@ -630,7 +630,7 @@ mod tests {
         }
         #[test]
         fn mint_without_enough_fees_error() {
-            let mut deps = mock_dependencies_with_custom_querier(&[]);
+            let mut deps = mock_desmos_dependencies();
             do_instantiate(deps.as_mut());
             let env = mock_env();
             let info = mock_info(USER, &coins(MINT_FEES - 1, DENOM));
@@ -681,7 +681,7 @@ mod tests {
         }
         #[test]
         fn mint_from_non_author_error() {
-            let mut deps = mock_dependencies_with_custom_querier(&[]);
+            let mut deps = mock_desmos_dependencies();
             do_instantiate(deps.as_mut());
             let env = mock_env();
             let info = mock_info(ADMIN, &coins(100, DENOM));
@@ -878,7 +878,7 @@ mod tests {
         use super::*;
         #[test]
         fn update_admin_without_permissions_error() {
-            let mut deps = mock_dependencies_with_custom_querier(&[]);
+            let mut deps = mock_desmos_dependencies();
             do_instantiate(deps.as_mut());
             let env = mock_env();
             let info = mock_info(USER, &vec![]);
@@ -894,7 +894,7 @@ mod tests {
         }
         #[test]
         fn update_admin_with_invalid_address_error() {
-            let mut deps = mock_dependencies_with_custom_querier(&[]);
+            let mut deps = mock_desmos_dependencies();
             do_instantiate(deps.as_mut());
             let env = mock_env();
             let info = mock_info(ADMIN, &vec![]);
@@ -910,7 +910,7 @@ mod tests {
         }
         #[test]
         fn update_admin_properly() {
-            let mut deps = mock_dependencies_with_custom_querier(&[]);
+            let mut deps = mock_desmos_dependencies();
             do_instantiate(deps.as_mut());
             let env = mock_env();
             let info = mock_info(ADMIN, &vec![]);
@@ -932,7 +932,7 @@ mod tests {
         use super::*;
         #[test]
         fn update_rarity_mint_fees_without_permissions_error() {
-            let mut deps = mock_dependencies_with_custom_querier(&[]);
+            let mut deps = mock_desmos_dependencies();
             do_instantiate(deps.as_mut());
             let env = mock_env();
             let info = mock_info(USER, &vec![]);
@@ -949,7 +949,7 @@ mod tests {
         }
         #[test]
         fn update_no_existing_rarity_mint_fees_error() {
-            let mut deps = mock_dependencies_with_custom_querier(&[]);
+            let mut deps = mock_desmos_dependencies();
             do_instantiate(deps.as_mut());
             let env = mock_env();
             let info = mock_info(ADMIN, &vec![]);
@@ -964,7 +964,7 @@ mod tests {
         }
         #[test]
         fn update_rarity_mint_fees_same_as_the_current_error() {
-            let mut deps = mock_dependencies_with_custom_querier(&[]);
+            let mut deps = mock_desmos_dependencies();
             do_instantiate(deps.as_mut());
             let env = mock_env();
             let info = mock_info(ADMIN, &vec![]);
@@ -979,7 +979,7 @@ mod tests {
         }
         #[test]
         fn update_rarity_mint_fees_properly() {
-            let mut deps = mock_dependencies_with_custom_querier(&[]);
+            let mut deps = mock_desmos_dependencies();
             do_instantiate(deps.as_mut());
             let env = mock_env();
             let info = mock_info(ADMIN, &vec![]);
@@ -1000,7 +1000,7 @@ mod tests {
         use super::*;
         #[test]
         fn query_config() {
-            let mut deps = mock_dependencies_with_custom_querier(&[]);
+            let mut deps = mock_desmos_dependencies();
             let env = mock_env();
             CONFIG
                 .save(
@@ -1029,7 +1029,7 @@ mod tests {
         }
         #[test]
         fn query_rarities() {
-            let mut deps = mock_dependencies_with_custom_querier(&[]);
+            let mut deps = mock_desmos_dependencies();
             let env = mock_env();
             RARITIES
                 .save(

--- a/contracts/remarkables/src/integration_tests.rs
+++ b/contracts/remarkables/src/integration_tests.rs
@@ -10,7 +10,9 @@ mod tests {
     use cw721_remarkables::Metadata;
     use cw_multi_test::{Contract, ContractWrapper, Executor};
     use desmos_bindings::{
-        mocks::mock_apps::{mock_desmos_app, mock_failing_desmos_app, DesmosApp, DesmosModule},
+        mocks::mock_apps::{
+            mock_desmos_app, mock_failing_desmos_app, DesmosApp, DesmosModule,
+        },
         msg::DesmosMsg,
         query::DesmosQuery,
     };

--- a/contracts/remarkables/src/integration_tests.rs
+++ b/contracts/remarkables/src/integration_tests.rs
@@ -10,9 +10,7 @@ mod tests {
     use cw721_remarkables::Metadata;
     use cw_multi_test::{Contract, ContractWrapper, Executor};
     use desmos_bindings::{
-        mocks::mock_apps::{
-            mock_desmos_app, mock_failing_desmos_app, DesmosApp, DesmosModule,
-        },
+        mocks::mock_apps::{mock_desmos_app, mock_failing_desmos_app, DesmosApp, DesmosModule},
         msg::DesmosMsg,
         query::DesmosQuery,
     };

--- a/contracts/remarkables/src/integration_tests.rs
+++ b/contracts/remarkables/src/integration_tests.rs
@@ -11,7 +11,7 @@ mod tests {
     use cw_multi_test::{Contract, ContractWrapper, Executor};
     use desmos_bindings::{
         mocks::mock_apps::{
-            custom_desmos_app, mock_failing_desmos_app, DesmosApp, FailingDesmosApp,
+            mock_desmos_app, mock_failing_desmos_app, DesmosApp, DesmosModule,
         },
         msg::DesmosMsg,
         query::DesmosQuery,
@@ -33,23 +33,10 @@ mod tests {
         .with_reply(crate::contract::reply);
         Box::new(contract)
     }
-    fn store_contracts(app: &mut DesmosApp) -> (u64, u64) {
+    fn store_contracts<M: DesmosModule>(app: &mut DesmosApp<M>) -> (u64, u64) {
         let cw721_code_id = app.store_code(CW721TestContract::success_contract());
         let remarkables_code_id = app.store_code(contract_remarkables());
         (cw721_code_id, remarkables_code_id)
-    }
-    fn store_contracts_to_failing_app(app: &mut FailingDesmosApp) -> (u64, u64) {
-        let cw721_code_id = app.store_code(CW721TestContract::success_contract());
-        let remarkables_code_id = app.store_code(contract_remarkables());
-        (cw721_code_id, remarkables_code_id)
-    }
-    fn mock_app() -> DesmosApp {
-        custom_desmos_app(|router, _, storage| {
-            router
-                .bank
-                .init_balance(storage, &Addr::unchecked(ADMIN), vec![])
-                .unwrap();
-        })
     }
     fn get_valid_init_msg(cw721_code_id: u64) -> InstantiateMsg {
         InstantiateMsg {
@@ -73,9 +60,8 @@ mod tests {
             ],
         }
     }
-    fn proper_instantiate() -> (DesmosApp, Addr, (u64, u64)) {
-        let mut app = mock_app();
-        let (cw721_code_id, remarkables_code_id) = store_contracts(&mut app);
+    fn proper_instantiate<M: DesmosModule>(app: &mut DesmosApp<M>) -> (Addr, (u64, u64)) {
+        let (cw721_code_id, remarkables_code_id) = store_contracts(app);
         let addr = app
             .instantiate_contract(
                 remarkables_code_id,
@@ -86,13 +72,13 @@ mod tests {
                 None,
             )
             .unwrap();
-        (app, addr, (cw721_code_id, remarkables_code_id))
+        (addr, (cw721_code_id, remarkables_code_id))
     }
     mod instantiate {
         use super::*;
         #[test]
         fn instantiate_with_invalid_cw721_code_id_error() {
-            let mut app = mock_app();
+            let mut app = mock_desmos_app();
             let (cw721_code_id, remarkables_code_id) = store_contracts(&mut app);
             let mut init_msg = get_valid_init_msg(cw721_code_id);
             // change code cw721_code_id to the invalid one
@@ -109,7 +95,7 @@ mod tests {
         }
         #[test]
         fn instantiate_with_failing_cw721_contract_error() {
-            let mut app = mock_app();
+            let mut app = mock_desmos_app();
             let (_, remarkables_code_id) = store_contracts(&mut app);
             let failing_cw721_code_id = app.store_code(CW721TestContract::failing_contract());
             let mut init_msg = get_valid_init_msg(failing_cw721_code_id);
@@ -128,7 +114,7 @@ mod tests {
         #[test]
         fn proper_instantiate_failing_app_error() {
             let mut app = mock_failing_desmos_app();
-            let (cw721_code_id, remarkables_code_id) = store_contracts_to_failing_app(&mut app);
+            let (cw721_code_id, remarkables_code_id) = store_contracts(&mut app);
             let result = app.instantiate_contract(
                 remarkables_code_id,
                 Addr::unchecked(ADMIN),
@@ -141,7 +127,8 @@ mod tests {
         }
         #[test]
         fn instantiate_propery() {
-            let (app, addr, (cw721_code_id, _)) = proper_instantiate();
+            let mut app = mock_desmos_app();
+            let (addr, (cw721_code_id, _)) = proper_instantiate(&mut app);
             let querier = app.wrap();
             // check config set properly
             let config: QueryConfigResponse = querier
@@ -155,7 +142,8 @@ mod tests {
         use super::*;
         #[test]
         fn mint_burned_token_error() {
-            let (mut app, addr, _) = proper_instantiate();
+            let mut app = mock_desmos_app();
+            let (addr, _) = proper_instantiate(&mut app);
             let config: QueryConfigResponse = app
                 .wrap()
                 .query_wasm_smart(&addr, &QueryMsg::Config {})
@@ -207,7 +195,8 @@ mod tests {
         }
         #[test]
         fn mint_properly() {
-            let (mut app, addr, _) = proper_instantiate();
+            let mut app = mock_desmos_app();
+            let (addr, _) = proper_instantiate(&mut app);
             app.execute(
                 Addr::unchecked(AUTHOR),
                 wasm_execute(
@@ -258,7 +247,8 @@ mod tests {
         use super::*;
         #[test]
         fn query_tokens() {
-            let (mut app, addr, _) = proper_instantiate();
+            let mut app = mock_desmos_app();
+            let (addr, _) = proper_instantiate(&mut app);
             app.execute(
                 Addr::unchecked(AUTHOR),
                 wasm_execute(
@@ -305,7 +295,8 @@ mod tests {
 
         #[test]
         fn query_nft_info() {
-            let (mut app, addr, _) = proper_instantiate();
+            let mut app = mock_desmos_app();
+            let (addr, _) = proper_instantiate(&mut app);
             app.execute(
                 Addr::unchecked(AUTHOR),
                 wasm_execute(

--- a/contracts/tips/Cargo.toml
+++ b/contracts/tips/Cargo.toml
@@ -41,6 +41,6 @@ cw-utils = "0.14.0"
 
 [dev-dependencies]
 cosmwasm-schema = "1.1.2"
-cw-multi-test = { version = "0.13.4" }
+cw-multi-test = "0.15.0"
 desmos-bindings = { version = "1.1.0", default-features = false, features = ["mocks"]}
 

--- a/contracts/tips/Cargo.toml
+++ b/contracts/tips/Cargo.toml
@@ -37,7 +37,7 @@ schemars = "0.8.10"
 serde = { version = "1.0.145", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.33" }
 desmos-bindings = { version = "1.1.0", default-features = false, features = ["posts", "subspaces", "profiles", "query"]}
-cw-utils = "0.14.0"
+cw-utils = "0.15.0"
 
 [dev-dependencies]
 cosmwasm-schema = "1.1.2"

--- a/contracts/tips/Cargo.toml
+++ b/contracts/tips/Cargo.toml
@@ -36,11 +36,11 @@ cw2 = "0.15.0"
 schemars = "0.8.10"
 serde = { version = "1.0.145", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.33" }
-desmos-bindings = { version = "1.1.0", default-features = false, features = ["posts", "subspaces", "profiles", "query"]}
+desmos-bindings = { version = "1.1.1", default-features = false, features = ["posts", "subspaces", "profiles", "query"]}
 cw-utils = "0.15.0"
 
 [dev-dependencies]
 cosmwasm-schema = "1.1.2"
 cw-multi-test = "0.15.0"
-desmos-bindings = { version = "1.1.0", default-features = false, features = ["mocks"]}
+desmos-bindings = { version = "1.1.1", default-features = false, features = ["mocks"]}
 

--- a/contracts/tips/Cargo.toml
+++ b/contracts/tips/Cargo.toml
@@ -31,13 +31,13 @@ optimize = """docker run --rm -v "$(pwd)"/../..:/code \
 [dependencies]
 cosmwasm-std = "1.0.0"
 cosmwasm-storage = "1.1.2"
-cw-storage-plus = "0.14.0"
-cw2 = "0.14.0"
+cw-storage-plus = "0.15.0"
+cw2 = "0.15.0"
 schemars = "0.8.10"
 serde = { version = "1.0.145", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.33" }
 desmos-bindings = { version = "1.1.0", default-features = false, features = ["posts", "subspaces", "profiles", "query"]}
-cw-utils = "0.14.0"
+cw-utils = "0.15.0"
 
 [dev-dependencies]
 cosmwasm-schema = "1.1.2"

--- a/contracts/tips/Cargo.toml
+++ b/contracts/tips/Cargo.toml
@@ -37,10 +37,10 @@ schemars = "0.8.10"
 serde = { version = "1.0.145", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.33" }
 desmos-bindings = { version = "1.1.0", default-features = false, features = ["posts", "subspaces", "profiles", "query"]}
-cw-utils = "0.15.0"
+cw-utils = "0.14.0"
 
 [dev-dependencies]
 cosmwasm-schema = "1.1.2"
-cw-multi-test = "0.15.0"
+cw-multi-test = { version = "0.13.4" }
 desmos-bindings = { version = "1.1.0", default-features = false, features = ["mocks"]}
 

--- a/contracts/tips/Cargo.toml
+++ b/contracts/tips/Cargo.toml
@@ -36,11 +36,11 @@ cw2 = "0.14.0"
 schemars = "0.8.10"
 serde = { version = "1.0.145", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.33" }
-desmos-bindings = { version = "1.0.3", default-features = false, features = ["posts", "subspaces", "profiles", "query"]}
+desmos-bindings = { version = "1.1.0", default-features = false, features = ["posts", "subspaces", "profiles", "query"]}
 cw-utils = "0.14.0"
 
 [dev-dependencies]
 cosmwasm-schema = "1.1.2"
 cw-multi-test = { version = "0.13.4" }
-desmos-bindings = { version = "1.0.3", default-features = false, features = ["mocks"]}
+desmos-bindings = { version = "1.1.0", default-features = false, features = ["mocks"]}
 

--- a/contracts/tips/src/contract.rs
+++ b/contracts/tips/src/contract.rs
@@ -485,7 +485,9 @@ mod tests {
         from_binary, Addr, BankMsg, Coin, Decimal, DepsMut, OwnedDeps, Response, StdError, SubMsg,
         SystemError, SystemResult, Uint64,
     };
-    use desmos_bindings::mocks::mock_queriers::mock_dependencies_with_custom_querier;
+    use desmos_bindings::mocks::mock_queriers::{
+        mock_desmos_dependencies, mock_desmos_dependencies_with_custom_querier, MockDesmosQuerier,
+    };
     use desmos_bindings::msg::DesmosMsg;
     use desmos_bindings::posts::query::PostsQuery;
     use desmos_bindings::profiles::mocks::mock_profiles_query_response;
@@ -581,7 +583,7 @@ mod tests {
 
     #[test]
     fn init_contract_with_invalid_subspace_id_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         let init_err = init_contract(
             deps.as_mut(),
@@ -595,7 +597,7 @@ mod tests {
 
     #[test]
     fn init_contract_with_invalid_tips_history_size_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         let init_err =
             init_contract(deps.as_mut(), 1, None, MAX_TIPS_HISTORY_SIZE + 1).unwrap_err();
@@ -654,7 +656,7 @@ mod tests {
 
     #[test]
     fn init_contract_with_empty_fixed_service_fees_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         // Simulate init with 100% of service fees
         let init_err = init_contract(
@@ -670,7 +672,7 @@ mod tests {
 
     #[test]
     fn init_contract_with_invalid_zero_fee_coin_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         // Simulate init with 100% of service fees
         let init_err = init_contract(
@@ -693,7 +695,7 @@ mod tests {
 
     #[test]
     fn init_contract_with_invalid_percentage_service_fees_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         // Simulate init with 100% of service fees
         let init_err = init_contract(
@@ -711,7 +713,7 @@ mod tests {
 
     #[test]
     fn init_contract_properly() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         init_contract(
             deps.as_mut(),
@@ -726,14 +728,14 @@ mod tests {
 
     #[test]
     fn init_contract_without_service_fee_properly() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         init_contract(deps.as_mut(), 1, None, 1).unwrap();
     }
 
     #[test]
     fn tip_user_with_invalid_address_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         init_contract(deps.as_mut(), 1, None, 5).unwrap();
 
@@ -756,7 +758,7 @@ mod tests {
 
     #[test]
     fn tip_with_empty_funds_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         init_contract(deps.as_mut(), 1, None, 5).unwrap();
 
@@ -774,7 +776,7 @@ mod tests {
 
     #[test]
     fn tip_to_yourself_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         init_contract(
             deps.as_mut(),
@@ -840,7 +842,7 @@ mod tests {
 
     #[test]
     fn tip_user_with_missing_fee_coin_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         init_contract(
             deps.as_mut(),
@@ -872,7 +874,7 @@ mod tests {
 
     #[test]
     fn tip_user_with_insufficient_amount_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         init_contract(
             deps.as_mut(),
@@ -904,7 +906,7 @@ mod tests {
 
     #[test]
     fn tip_user_with_zero_fees_properly() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         init_contract(deps.as_mut(), 1, None, 5).unwrap();
 
@@ -938,7 +940,7 @@ mod tests {
 
     #[test]
     fn tip_user_with_fixed_fees_properly() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         init_contract(
             deps.as_mut(),
@@ -980,7 +982,7 @@ mod tests {
 
     #[test]
     fn tip_user_with_percentage_fees_properly() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         init_contract(
             deps.as_mut(),
@@ -1022,7 +1024,7 @@ mod tests {
 
     #[test]
     fn tip_post_with_invalid_post_id_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         init_contract(
             deps.as_mut(),
@@ -1096,7 +1098,7 @@ mod tests {
 
     #[test]
     fn tip_post_with_missing_fee_coin_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         init_contract(
             deps.as_mut(),
@@ -1128,7 +1130,7 @@ mod tests {
 
     #[test]
     fn tip_post_with_insufficient_fees_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         init_contract(
             deps.as_mut(),
@@ -1160,7 +1162,7 @@ mod tests {
 
     #[test]
     fn tip_post_with_zero_fees_properly() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         init_contract(deps.as_mut(), 1, None, 5).unwrap();
 
@@ -1191,7 +1193,7 @@ mod tests {
 
     #[test]
     fn tip_post_with_fixed_fees_properly() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         init_contract(
             deps.as_mut(),
@@ -1229,7 +1231,7 @@ mod tests {
 
     #[test]
     fn tip_post_with_percentage_fees_properly() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         init_contract(
             deps.as_mut(),
@@ -1267,7 +1269,7 @@ mod tests {
 
     #[test]
     fn tips_reach_tips_history_size_properly() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         init_contract(
             deps.as_mut(),
@@ -1327,7 +1329,7 @@ mod tests {
 
     #[test]
     fn tip_without_tips_history_properly() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         init_contract(
             deps.as_mut(),
@@ -1354,7 +1356,7 @@ mod tests {
 
     #[test]
     fn update_service_fees_with_invalid_admin_address_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         init_contract(
             deps.as_mut(),
@@ -1383,7 +1385,7 @@ mod tests {
 
     #[test]
     fn update_service_fee_with_empty_fixed_fee_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         init_contract(
             deps.as_mut(),
@@ -1410,7 +1412,7 @@ mod tests {
 
     #[test]
     fn update_service_fee_with_zero_fee_coin_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         init_contract(
             deps.as_mut(),
@@ -1444,7 +1446,7 @@ mod tests {
 
     #[test]
     fn update_service_fee_with_invalid_percentage_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         init_contract(
             deps.as_mut(),
@@ -1473,7 +1475,7 @@ mod tests {
 
     #[test]
     fn update_service_fee_properly() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         init_contract(
             deps.as_mut(),
@@ -1510,7 +1512,7 @@ mod tests {
 
     #[test]
     fn clear_service_fee_properly() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         init_contract(
             deps.as_mut(),
@@ -1536,7 +1538,7 @@ mod tests {
 
     #[test]
     fn update_admin_from_non_admin_user_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         init_contract(
             deps.as_mut(),
@@ -1563,7 +1565,7 @@ mod tests {
 
     #[test]
     fn update_admin_with_invalid_admin_address_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         init_contract(
             deps.as_mut(),
@@ -1595,7 +1597,7 @@ mod tests {
 
     #[test]
     fn update_admin_properly() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         init_contract(
             deps.as_mut(),
@@ -1623,7 +1625,7 @@ mod tests {
 
     #[test]
     fn update_tips_history_size_from_non_admin_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         init_contract(
             deps.as_mut(),
@@ -1647,7 +1649,7 @@ mod tests {
 
     #[test]
     fn update_tips_history_with_invalid_size_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         init_contract(
             deps.as_mut(),
@@ -1680,7 +1682,7 @@ mod tests {
 
     #[test]
     fn update_tips_history_properly() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         init_contract(
             deps.as_mut(),
@@ -1703,7 +1705,7 @@ mod tests {
 
     #[test]
     fn update_tips_history_size_records_wipe_properly() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         init_contract(
             deps.as_mut(),
@@ -1757,7 +1759,7 @@ mod tests {
 
     #[test]
     fn update_tips_history_size_tips_history_shrinks_properly() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         init_contract(deps.as_mut(), 1, None, 5).unwrap();
 
@@ -1839,7 +1841,7 @@ mod tests {
 
     #[test]
     fn claim_fee_from_non_admin_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         init_contract(
             deps.as_mut(),
@@ -1866,7 +1868,10 @@ mod tests {
 
     #[test]
     fn claim_fee_properly() {
-        let mut deps = mock_dependencies_with_custom_querier(&[Coin::new(2000, "udsm")]);
+        let mut deps = mock_desmos_dependencies_with_custom_querier(MockDesmosQuerier::new(&[(
+            MOCK_CONTRACT_ADDR,
+            &[Coin::new(2000, "udsm")],
+        )]));
 
         init_contract(
             deps.as_mut(),
@@ -1899,7 +1904,7 @@ mod tests {
 
     #[test]
     fn query_config_properly() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         init_contract(
             deps.as_mut(),
@@ -1927,7 +1932,7 @@ mod tests {
 
     #[test]
     fn query_user_received_tips_properly() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         init_contract(
             deps.as_mut(),
@@ -2023,7 +2028,7 @@ mod tests {
 
     #[test]
     fn query_user_sent_tips_properly() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         init_contract(
             deps.as_mut(),
@@ -2111,7 +2116,7 @@ mod tests {
 
     #[test]
     fn query_tips_with_invalid_post_id_error() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         init_contract(
             deps.as_mut(),
@@ -2137,7 +2142,7 @@ mod tests {
 
     #[test]
     fn query_tips_with_not_tipped_post_id_properly() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         init_contract(
             deps.as_mut(),
@@ -2164,7 +2169,7 @@ mod tests {
 
     #[test]
     fn query_post_received_tips_properly() {
-        let mut deps = mock_dependencies_with_custom_querier(&[]);
+        let mut deps = mock_desmos_dependencies();
 
         init_contract(
             deps.as_mut(),


### PR DESCRIPTION
This PR bumps desmos bindings to v1.1.1 and it includes bumping cw-multi-test to v0.15.0.
It needs to wait for the following deps PR to fix bugs.
deps: 
- https://github.com/desmos-labs/desmos-bindings/pull/68