### PR TITLE
fix: fixed typo in remarkables

### DIFF
--- a/contracts/remarkables/schema/execute_msg.json
+++ b/contracts/remarkables/schema/execute_msg.json
@@ -37,10 +37,10 @@
       "description": "Message allowing the contract administrator to update the mint fees of the given rarity level.",
       "type": "object",
       "required": [
-        "update_rarity_mint_fee"
+        "update_rarity_mint_fees"
       ],
       "properties": {
-        "update_rarity_mint_fee": {
+        "update_rarity_mint_fees": {
           "type": "object",
           "required": [
             "new_fees",

--- a/contracts/remarkables/src/contract.rs
+++ b/contracts/remarkables/src/contract.rs
@@ -120,7 +120,7 @@ pub fn execute(
             rarity_level,
         } => execute_mint(deps, info, rarity_level, post_id.into(), remarkables_uri),
         ExecuteMsg::UpdateAdmin { new_admin } => execute_update_admin(deps, info, new_admin),
-        ExecuteMsg::UpdateRarityMintFee {
+        ExecuteMsg::UpdateRarityMintFees {
             rarity_level,
             new_fees,
         } => execute_update_rarity_mint_fees(deps, info, rarity_level, new_fees),
@@ -936,7 +936,7 @@ mod tests {
             do_instantiate(deps.as_mut());
             let env = mock_env();
             let info = mock_info(USER, &vec![]);
-            let msg = ExecuteMsg::UpdateRarityMintFee {
+            let msg = ExecuteMsg::UpdateRarityMintFees {
                 rarity_level: RARITY_LEVEL,
                 new_fees: coins(50, DENOM),
             };
@@ -953,7 +953,7 @@ mod tests {
             do_instantiate(deps.as_mut());
             let env = mock_env();
             let info = mock_info(ADMIN, &vec![]);
-            let msg = ExecuteMsg::UpdateRarityMintFee {
+            let msg = ExecuteMsg::UpdateRarityMintFees {
                 rarity_level: 2,
                 new_fees: coins(50, DENOM),
             };
@@ -968,7 +968,7 @@ mod tests {
             do_instantiate(deps.as_mut());
             let env = mock_env();
             let info = mock_info(ADMIN, &vec![]);
-            let msg = ExecuteMsg::UpdateRarityMintFee {
+            let msg = ExecuteMsg::UpdateRarityMintFees {
                 rarity_level: RARITY_LEVEL,
                 new_fees: coins(MINT_FEES, DENOM),
             };
@@ -983,7 +983,7 @@ mod tests {
             do_instantiate(deps.as_mut());
             let env = mock_env();
             let info = mock_info(ADMIN, &vec![]);
-            let msg = ExecuteMsg::UpdateRarityMintFee {
+            let msg = ExecuteMsg::UpdateRarityMintFees {
                 rarity_level: RARITY_LEVEL,
                 new_fees: coins(50, DENOM),
             };

--- a/contracts/remarkables/src/msg.rs
+++ b/contracts/remarkables/src/msg.rs
@@ -54,7 +54,7 @@ pub enum ExecuteMsg {
         rarity_level: u32,
     },
     /// Message allowing the contract administrator to update the mint fees of the given rarity level.
-    UpdateRarityMintFee {
+    UpdateRarityMintFees {
         rarity_level: u32,
         new_fees: Vec<Coin>,
     },

--- a/docs/architecture/adr-003-remarkables-contract.md
+++ b/docs/architecture/adr-003-remarkables-contract.md
@@ -93,7 +93,7 @@ pub struct Metadata {
 ```rust
 pub enum ExecuteMsg{
   Mint{post_id: u64, remarkable_uri: String, rarity_level: u64},
-  UpdateRarityMintFee{rarity_level: u64, new_fee: Vec<Coin>},
+  UpdateRarityMintFees{rarity_level: u64, new_fee: Vec<Coin>},
   UpdateAdmin{new_admin: String}
 }
 ```
@@ -114,8 +114,8 @@ The `Mint<T>` message fields of the `CW721-base` should be filled as follows:
 
 The usage of the extention field here is not needed.
 
-##### UpdateRarityMintFee
-With the `UpdateRarityMintFee{rarity_level, new_fee}` message the `admin` of the contract can update the fees associated with
+##### UpdateRarityMintFees
+With the `UpdateRarityMintFees{rarity_level, new_fee}` message the `admin` of the contract can update the fees associated with
 a given rarity level. Here we need to check that:
 * The contract `sender` is the admin;
 * The `rarity_level` exists;


### PR DESCRIPTION
This PR fixes the typo in the remarkables contract.