### PR TITLE
fix: added missing claim fees method to remarkables contract

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,8 +38,3 @@ jobs:
         run: cargo test
         env:
           RUST_BACKTRACE: 1
-
-      - name: Test tips contract 🧪
-        run: cargo test --package tips
-        env:
-          RUST_BACKTRACE: 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -705,6 +705,7 @@ dependencies = [
 name = "remarkables"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",

--- a/contracts/remarkables/Cargo.toml
+++ b/contracts/remarkables/Cargo.toml
@@ -47,3 +47,4 @@ cw721-remarkables = { path = "../cw721-remarkables", version = "0.1.0", features
 cosmwasm-schema = "1.0.0"
 cw-multi-test = "0.15.0"
 desmos-bindings = { version = "1.1.1", default-features = false, features = ["mocks"] }
+anyhow = "1.0.65"

--- a/contracts/remarkables/schema/all_nft_info_response_for__metadata.json
+++ b/contracts/remarkables/schema/all_nft_info_response_for__metadata.json
@@ -24,6 +24,7 @@
       ]
     }
   },
+  "additionalProperties": false,
   "definitions": {
     "Approval": {
       "type": "object",
@@ -44,7 +45,8 @@
           "description": "Account that can transfer/send the token",
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
@@ -85,7 +87,8 @@
           ],
           "properties": {
             "never": {
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             }
           },
           "additionalProperties": false
@@ -138,7 +141,8 @@
             "null"
           ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "OwnerOfResponse": {
       "type": "object",
@@ -158,7 +162,8 @@
           "description": "Owner of the token",
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "Timestamp": {
       "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",

--- a/contracts/remarkables/schema/execute_msg.json
+++ b/contracts/remarkables/schema/execute_msg.json
@@ -83,6 +83,27 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "description": "Message allowing the contract's admin to claim fees in this contract.",
+      "type": "object",
+      "required": [
+        "claim_fees"
+      ],
+      "properties": {
+        "claim_fees": {
+          "type": "object",
+          "required": [
+            "receiver"
+          ],
+          "properties": {
+            "receiver": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {

--- a/contracts/remarkables/schema/instantiate_msg.json
+++ b/contracts/remarkables/schema/instantiate_msg.json
@@ -82,7 +82,8 @@
           "description": "Symbol of the NFT contract",
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "Rarity": {
       "type": "object",

--- a/contracts/remarkables/schema/tokens_response.json
+++ b/contracts/remarkables/schema/tokens_response.json
@@ -13,5 +13,6 @@
         "type": "string"
       }
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/contracts/remarkables/src/msg.rs
+++ b/contracts/remarkables/src/msg.rs
@@ -60,6 +60,8 @@ pub enum ExecuteMsg {
     },
     /// Message allowing the contract's admin to transfer the admin rights to another user.
     UpdateAdmin { new_admin: String },
+    /// Message allowing the contract's admin to claim fees in this contract.
+    ClaimFees { receiver: String },
 }
 
 impl ExecuteMsg {

--- a/contracts/remarkables/src/test_utils.rs
+++ b/contracts/remarkables/src/test_utils.rs
@@ -134,6 +134,7 @@ impl Module for DesmosKeeper {
                 }
                 _ => unimplemented!(),
             },
+            _ => unimplemented!(),
         }
     }
     fn sudo<ExecC, QueryC>(

--- a/docs/architecture/adr-003-remarkables-contract.md
+++ b/docs/architecture/adr-003-remarkables-contract.md
@@ -94,7 +94,8 @@ pub struct Metadata {
 pub enum ExecuteMsg{
   Mint{post_id: u64, remarkable_uri: String, rarity_level: u64},
   UpdateRarityMintFees{rarity_level: u64, new_fee: Vec<Coin>},
-  UpdateAdmin{new_admin: String}
+  UpdateAdmin{new_admin: String},
+  ClaimFees{receiver: String}
 }
 ```
 
@@ -126,6 +127,11 @@ With the `UpdateAdmin{new_admin}` message, the current admin can choose another 
 Here we need to check that:
 * The contract `sender` is the admin;
 * The `new_admin` is the new admin of the subspace also.
+
+##### ClaimFees
+With the `ClaimFees` message the contract's admin can withdraw all the collected fees and send them to the given `recipient`.
+The `recipient` can be a user or another contract. Here we need to check that:
+* The contract `sender` is the admin.
 
 ### Query
 ```rust


### PR DESCRIPTION
This PR added `ClaimFees` method to remarkables since the admin should have an access to claim the fees in the contract.