### PR TITLE
docs: add contributing guidelines

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,22 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: 'bug'
+assignees: 'manu0466'
+
+---
+<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺ 
+v                            ✰  Thanks for opening an issue! ✰    
+v    Before smashing the submit button please review the template.
+v    Please also ensure that this is not a duplicate issue :)  
+☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  --> 
+
+## Bug description
+<!-- A clear and concise description of what the bug is. -->
+
+## Steps to reproduce
+<!-- Steps to reproduce the bug --> 
+
+## Expected behavior
+<!-- A clear and concise description of what you expected to happen. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: 'new-feature'
+assignees: ''
+
+---
+<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺ 
+v                            ✰  Thanks for opening an issue! ✰    
+v    Before smashing the submit button please review the template.
+v    Word of caution: poorly thought-out proposals may be rejected 
+v                     without deliberation 
+☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  --> 
+
+## Feature description
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+## Implementation proposal
+<!-- A clear and concise description of what you would want to happen. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,43 @@
+## Description
+
+Closes: #XXXX
+
+<!-- Add a description of the changes that this PR introduces and the files that
+are the most critical to review. -->
+
+---
+
+### Author Checklist
+
+*All items are required. Please add a note to the item if the item is not applicable and
+please add links to any relevant follow up issues.*
+
+I have...
+
+- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
+- [ ] added `!` to the type prefix if API or client breaking change
+- [ ] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
+- [ ] provided a link to the relevant issue or specification
+- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
+- [ ] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
+- [ ] added a changelog entry to `CHANGELOG.md`
+- [ ] updated the relevant documentation or specification
+- [ ] reviewed "Files changed" and left comments if necessary
+- [ ] confirmed all CI checks have passed
+
+### Reviewers Checklist
+
+*All items are required. Please add a note if the item is not applicable and please add
+your handle next to the items reviewed if you only reviewed selected items.*
+
+I have...
+
+- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
+- [ ] confirmed `!` in the type prefix if API or client breaking change
+- [ ] confirmed all author checklist items have been addressed
+- [ ] reviewed contract logic
+- [ ] reviewed contract security
+- [ ] reviewed API design and naming
+- [ ] reviewed documentation is accurate
+- [ ] reviewed tests and test coverage
+- [ ] manually tested (if applicable)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,10 +16,9 @@ I have...
 
 - [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
 - [ ] added `!` to the type prefix if API or client breaking change
-- [ ] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
+- [ ] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos-contracts/blob/master/CONTRIBUTING.md#pr-targeting))
 - [ ] provided a link to the relevant issue or specification
-- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
-- [ ] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
+- [ ] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos-contracts/blob/master/CONTRIBUTING.md#testing)
 - [ ] added a changelog entry to `CHANGELOG.md`
 - [ ] updated the relevant documentation or specification
 - [ ] reviewed "Files changed" and left comments if necessary

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,203 @@
+# Contributing
+
+- [Contributing](#contributing)
+    - [Architecture Decision Records (ADR)](#architecture-decision-records-adr)
+    - [Pull Requests](#pull-requests)
+        - [Requesting Reviews](#requesting-reviews)
+        - [Reviewing Pull Requests](#reviewing-pull-requests)
+    - [Coding Style](#coding-style)
+        - [Naming Conventions](#naming-conventions) 
+        - [Execute/Query Actions](#executequery-actions)
+        - [Messages](#messages)
+        - [Field Types](#field-types)
+        - [Instantiate/Execute Validation](#instantiateexecute-validation)
+        - [Query](#query)
+    - [Testing](#testing)
+    - [Branching Model and Release](#branching-model-and-release)
+        - [PR Targeting](#pr-targeting)
+        - [Development Procedure](#development-procedure)
+        - [Pull Merge Procedure](#pull-merge-procedure)
+
+Thank you for considering making contributions to Desmos and related repositories!
+
+Contributing to this repo can mean many things such as participating in discussion or proposing code changes. To ensure
+a smooth workflow for all contributors, the general procedure for contributing has been established:
+
+1. Either [open](https://github.com/desmos-labs/desmos-contracts/issues/new/choose) or
+   [find](https://github.com/desmos-labs/desmos-contracts/issues) an issue you'd like to help with
+2. Participate in thoughtful discussion on that issue
+3. If you would like to contribute:
+    1. If the issue is a proposal, ensure that the proposal has been accepted
+    2. Ensure that nobody else has already begun working on this issue. If they have, make sure to contact them to
+       collaborate
+    3. If nobody has been assigned for the issue and you would like to work on it, make a comment on the issue to inform
+       the community of your intentions to begin work
+    4. Follow standard GitHub best practices: fork the repo, branch from the HEAD of `master`, make some commits, and
+       submit a PR to `master`
+        - For core developers working within the repo, to ensure a clear ownership of branches, branches must be
+          named with the convention
+          `{moniker}/{issue#}/branch-name`
+    5. Be sure to submit the PR in `Draft` mode if you want to receive early feedback, even if it's incomplete as this
+       indicates to the community you're working on something and allows them to provide comments early in the
+       development process
+    6. When the code is complete it can be marked `Ready for Review`
+
+Note that for very small or blatantly obvious problems (such as typos) it is not required to an open issue to submit a
+PR, but be aware that for more complex problems/features, if a PR is opened before an adequate design discussion has
+taken place in a GitHub issue, that PR runs a high likelihood of being rejected.
+
+Other notes:
+
+- Looking for a good place to start contributing? How about checking out some
+  [good first issues](https://github.com/desmos-labs/desmos-contracts/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
+- Please ensure that your code is lint compliant by running `cargo clippy`.
+
+## Architecture Decision Records (ADR)
+
+When proposing an architecture decision for a smart contract, please start by opening an
+[issue](https://github.com/desmos-labs/desmos/issues/new/choose) or a
+[discussion](https://github.com/desmos-labs/desmos/discussions/new) with a summary of the proposal. Once the proposal
+has been discussed and there is rough alignment on a high-level approach to the design,
+the [ADR creation process](https://github.com/desmos-labs/desmos/blob/master/docs/architecture/PROCESS.md) can begin. We
+are following this process to ensure all involved parties are in agreement before any party begins coding the proposed
+implementation. If you would like to see examples of how these are written, please refer to the current
+[ADRs](https://github.com/desmos-labs/desmos-contracts/tree/master/docs/architecture) or to
+[Cosmos ADRs](https://github.com/cosmos/cosmos-sdk/tree/master/docs/architecture).
+
+## Coding Style
+
+#### Naming Conventions
+
+Each message must be in PascalCase like in the example below:
+
+```rust
+pub enum ExecuteMsg {
+    IncrementCount {},
+}
+```
+
+#### Execute/Query Actions
+
+For each execute/query message a function that implements that functionality must be created.
+In the case that two messages do similar operations it is allowed to create a single function for both actions.
+
+### Messages
+
+All the **execute** and **query** messages should be defined inside a `msg.rs` file.
+
+#### Field Types
+
+These are the types that we enforce for each use case:
+* `String`: to represent an address, this is to force the address validation to convert an address to the `Addr` struct;
+**NOTE**: This is just for the `Execute` and `Instantiate` messages. Inside the query responses we use the `Addr` type.
+* `U\Int64\128`: to represent any number that is bigger than 32 bits,
+this is to ensure any client that doesn’t have a proper support for such larger integer can handle them correctly.
+
+#### Instantiate/Execute Validation
+
+In order to keep the validation logic of the Execute/Instantiate messages in a single place we enforce that the 
+messages must implement a `pub fn validate(&self) -> bool` method to make sure that the fields are correct.
+For example, if a message have a start and end time to express a period of time, t
+his method should ensure that the start time is before the end time. This method **should not** validate any address 
+in the messages.
+
+#### Query
+
+For each query message we return an appropriate `QueryResponse` struct that contains the queried data. 
+For example, if there's a `QueryAdmin` message, must be created a `QueryAdminResponse` struct containing 
+the contract admin address.
+
+## Pull Requests
+
+PRs should be categorically broken up based on the type of changes being made (for example, `fix`, `feat`,
+`refactor`, `docs`, and so on). The *type* must be included in the PR title as a prefix (for example,
+`fix: <description>`). This convention ensures that all changes that are committed to the base branch follow the
+[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification. Additionally, each PR should only
+address a single issue.
+
+### Requesting Reviews
+
+In order to accommodate the review process, the author of the PR must complete the author checklist to the best of their
+abilities before marking the PR as "Ready for Review". If you would like to receive early feedback on the PR, open the
+PR as a "Draft" and leave a comment in the PR indicating that you would like early feedback and tagging whoever you
+would like to receive feedback from.
+
+### Reviewing Pull Requests
+
+All PRs require at least two review approvals before they can be merged (one review might be acceptable in the case of
+minor changes to docs or other changes that do not affect production code). The PR template has a reviewers checklist
+that must be completed before the PR can be merged. Each reviewer is responsible for all checked items unless they have
+indicated otherwise by leaving their handle next to specific items. In addition, use the following review explanations:
+
+- `LGTM` without an explicit approval means that the changes look good, but you haven't thoroughly reviewed the reviewer
+  checklist items.
+- `Approval` means that you have completed some or all of the reviewer checklist items. If you only reviewed selected
+  items, you must add your handle next to the items that you have reviewed. In addition, follow these guidelines:
+    - You must also think through anything which ought to be included but is not
+    - You must think through whether any added code could be partially combined (DRYed) with existing code
+    - You must think through any potential security issues or incentive-compatibility flaws introduced by the changes
+    - Naming must be consistent with conventions and the rest of the codebase
+    - Code must live in a reasonable location, considering dependency structures (for example, not importing testing
+      modules in production code, or including example code modules in production code).
+    - If you approve the PR, you are responsible for any issues mentioned here and any issues that should have been
+      addressed after thoroughly reviewing the reviewer checklist items in the pull request template.
+- If you sat down with the PR submitter and did a pairing review, add this information in the `Approval` or your PR
+  comments.
+- If you are only making "surface level" reviews, submit any notes as `Comments` without adding a review.
+
+## Testing
+
+To ensure that the smart contracts behave correctly we enforce the presence of **unit tests**. In the case the contract
+is also interacting with one or more contracts we enforce the presence of
+**integration tests** to check if the state of the other contracts are coherent with the action performed from the
+contract under test.
+
+### Check success of an action
+
+It is recommended to use `unwrap` over `assert!(r.is_ok())` to check that an action’s returned `Result` is `Ok`. Doing
+this, more details will be returned when the `Result` is not `Ok` since the `unwrap` function will panic writing on the
+test log the error. If necessary, after calling `unwrap`, the unwrapped structure can be checked using `assert_eq!`. It
+is also **mandatory** to check that the contract has the expected state after the execution.
+
+### Check failure of an action
+
+It is recommended to use `unwrap_err` over `assert!(r.is_err())` to check that an action’s returned `Result` is `Err`.
+Doing this, more details will be returned when the `Result` is not `Err` since the `unwrap_err` function will 
+panic writing on the test log the occurred errors.
+Where possible, after unwrapping the error, it is **mandatory** to check that the returned error is what the contract 
+should return in that failure case.
+
+### Single responsibility 
+Each test should be scoped to a **single case**. For example if an execution action have 2 possible
+cause of failure there should be 3 tests, 2 that tests the error cases and 1 to check the proper execution.
+
+### Naming conventions
+The tests name should describe explicitly in the title what it’s going to test and follow the following naming convention:
+
+* Proper execution tests: `..._properly`;
+* Failure tests: `..._error`.
+
+## Branching Model and Release
+
+User-facing repos should adhere to the [trunk based development branching model](https://trunkbaseddevelopment.com/).
+
+### PR Targeting
+
+Ensure that you base and target your PR on the `master` branch.
+
+All feature additions and bug fixes should be targeted against `master`.
+
+### Development Procedure
+
+- the latest state of development is on `master`
+- `master` must never fail `cargo test`
+- `master` should not fail `cargo clippy`
+- no `--force` onto `master` (except when reverting a broken commit, which should seldom happen)
+- create a development branch either on github.com/desmos-labs/desmos-contracts, or your fork (using `git remote add origin`)
+- before submitting a pull request, begin `git rebase` on top of `master`
+
+### Pull Merge Procedure
+
+- ensure pull branch is rebased on `master`
+- run `cargo test` to ensure that all tests pass
+- merge pull request

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,10 +55,10 @@ Other notes:
 ## Architecture Decision Records (ADR)
 
 When proposing an architecture decision for a smart contract, please start by opening an
-[issue](https://github.com/desmos-labs/desmos/issues/new/choose) or a
-[discussion](https://github.com/desmos-labs/desmos/discussions/new) with a summary of the proposal. Once the proposal
+[issue](https://github.com/desmos-labs/desmos-contracts/issues/new/choose) or a
+[discussion](https://github.com/desmos-labs/desmos-contracts/discussions/new) with a summary of the proposal. Once the proposal
 has been discussed and there is rough alignment on a high-level approach to the design,
-the [ADR creation process](https://github.com/desmos-labs/desmos/blob/master/docs/architecture/PROCESS.md) can begin. We
+the [ADR creation process](https://github.com/desmos-labs/desmos-contracts/blob/master/docs/architecture/PROCESS.md) can begin. We
 are following this process to ensure all involved parties are in agreement before any party begins coding the proposed
 implementation. If you would like to see examples of how these are written, please refer to the current
 [ADRs](https://github.com/desmos-labs/desmos-contracts/tree/master/docs/architecture) or to

--- a/docs/architecture/PROCESS.md
+++ b/docs/architecture/PROCESS.md
@@ -1,0 +1,56 @@
+# ADR Creation Process
+
+1. Copy the `adr-template.md` file. Use the following filename pattern: `adr-next_number-title.md`
+2. Create a draft Pull Request if you want to get an early feedback.
+3. Make sure the context and a solution is clear and well documented.
+4. Add an entry to a list in the [README](./README.md) file.
+5. Create a Pull Request to propose a new ADR.
+
+## ADR life cycle
+
+ADR creation is an **iterative** process. Instead of trying to solve all decisions in a single ADR pull request, we MUST firstly understand the problem and collect feedback through a GitHub Issue.
+
+1. Every proposal SHOULD start with a new GitHub Issue or be a result of existing Issues. The Issue should contain just a brief proposal summary.
+
+2. Once the motivation is validated, a GitHub Pull Request (PR) is created with a new document based on the `adr-template.md`.
+
+3. An ADR doesn't have to arrive to `master` with an _accepted_ status in a single PR. If the motivation is clear and the solution is sound, we SHOULD be able to merge it and keep a _proposed_ status. It's preferable to have an iterative approach rather than long, not merged Pull Requests.
+
+4. If a _proposed_ ADR is merged, then it should clearly document outstanding issues either in ADR document notes or in a GitHub Issue.
+
+5. The PR SHOULD always be merged. In the case of a faulty ADR, we still prefer to  merge it with a _rejected_ status. The only time the ADR SHOULD NOT be merged is if the author abandons it.
+
+6. Merged ADRs SHOULD NOT be pruned.
+
+### ADR status
+
+Status has two components:
+
+```
+{CONSENSUS STATUS} {IMPLEMENTATION STATUS}
+```
+
+IMPLEMENTATION STATUS is either `Implemented` or `Not Implemented`.
+
+#### Consensus Status
+
+```
+DRAFT -> PROPOSED -> LAST CALL yyyy-mm-dd -> ACCEPTED | REJECTED -> SUPERSEEDED by ADR-xxx
+                  \        |
+                   \       |
+                    v      v
+                     ABANDONED
+```
+
++ `DRAFT`: [optional] an ADR which is work in progress, not being ready for a general review. This is to present an early work and get an early feedback in a Draft Pull Request form.
++ `PROPOSED`: an ADR covering a full solution architecture and still in the review - project stakeholders haven't reached an agreed yet.
++ `LAST CALL <date for the last call>`: [optional] clear notify that we are close to accept updates. Changing a status to `LAST CALL` means that social consensus (of Desmos maintainers) has been reached and we still want to give it a time to let the community react or analyze.
++ `ACCEPTED`: ADR which will represent a currently implemented or to be implemented architecture design.
++ `REJECTED`: ADR can go from PROPOSED or ACCEPTED to rejected if the consensus among project stakeholders will decide so.
++ `SUPERSEEDED by ADR-xxx`: ADR which has been superseded by a new ADR.
++ `ABANDONED`: the ADR is no longer pursued by the original authors.
+
+## Language used in ADR
+
++ The context/background should be written in the present tense.
++ Avoid using a first, personal form.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,49 @@
+# Architecture Decision Records (ADR)
+
+This is a location to record all high-level architecture decisions in Desmos.
+
+An Architectural Decision (**AD**) is a software design choice that addresses a functional or non-functional requirement that is architecturally significant.
+An Architecturally Significant Requirement (**ASR**) is a requirement that has a measurable effect on a software system’s architecture and quality.
+An Architectural Decision Record (**ADR**) captures a single AD, such as often done when writing personal notes or meeting minutes; the collection of ADRs created and maintained in a project constitute its decision log. All these are within the topic of Architectural Knowledge Management (AKM).
+
+You can read more about the ADR concept in this [blog post](https://product.reverb.com/documenting-architecture-decisions-the-reverb-way-a3563bb24bd0#.78xhdix6t).
+
+## Rationale
+
+ADRs are intended to be the primary mechanism for proposing new feature designs and new processes, for collecting community input on an issue, and for documenting the design decisions.
+An ADR should provide:
+
+- Context on the relevant goals and the current state
+- Proposed changes to achieve the goals
+- Summary of pros and cons
+- References
+- Changelog
+
+Note the distinction between an ADR and a spec. The ADR provides the context, intuition, reasoning, and
+justification for a change in architecture, or for the architecture of something
+new. The spec is much more compressed and streamlined summary of everything as
+it stands today.
+
+If recorded decisions turned out to be lacking, convene a discussion, record the new decisions here, and then modify the code to match.
+
+## Creating new ADR
+
+Read about the [PROCESS](./PROCESS.md).
+
+#### Use RFC 2119 Keywords
+
+When writing ADRs, follow the same best practices for writing RFCs. When writing RFCs, key words are used to signify the requirements in the specification. These words are often capitalized: "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL. They are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
+
+## ADR Table of Contents
+
+### Accepted
+
+* ADR 001: [Poap Contract](https://github.com/desmos-labs/desmos-contracts/blob/master/docs/architecture/adr-001-poap-contract.md)
+* ADR 002: [Poap Manager Contract](https://github.com/desmos-labs/desmos-contracts/blob/master/docs/architecture/adr-002-poap-manager-contract.md)
+* ADR 003: [Remarkables Contract](https://github.com/desmos-labs/desmos-contracts/blob/master/docs/architecture/adr-003-remarkables-contract.md)
+* ADR 004: [Tips Contract](https://github.com/desmos-labs/desmos-contracts/blob/master/docs/architecture/adr-004-tips-contract.md)
+* ADR 005: [Social Tips Contract](https://github.com/desmos-labs/desmos-contracts/blob/master/docs/architecture/adr-005-social-tips-contract.md)
+
+### Proposed
+
+### Draft

--- a/docs/architecture/adr-template.md
+++ b/docs/architecture/adr-template.md
@@ -1,0 +1,60 @@
+# ADR {ADR-NUMBER}: {TITLE}
+
+## Changelog
+
+- {date}: {changelog}
+
+## Status
+
+{DRAFT | PROPOSED} Not Implemented
+
+> Please have a look at the [PROCESS](./PROCESS.md#adr-status) page.
+> Use DRAFT if the ADR is in a draft stage (draft PR) or PROPOSED if it's in review.
+
+## Abstract
+
+> "If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the ADR.
+> A short (~200 word) description of the issue being addressed.
+
+## Context
+
+> This section describes the forces at play, including technological, political, social, and project local. These forces are probably in tension, and should be called out as such. The language in this section is value-neutral. It is simply describing facts. It should clearly explain the problem and motivation that the proposal aims to resolve.
+> {context body}
+
+## Decision
+
+> This section describes our response to these forces. It is stated in full sentences, with active voice. "We will ..."
+> {decision body}
+
+## Consequences
+
+> This section describes the resulting context, after applying the decision. All consequences should be listed here, not just the "positive" ones. A particular decision may have positive, negative, and neutral consequences, but all of them affect the team and project in the future.
+
+### Backwards Compatibility
+
+> All ADRs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The ADR must explain how the author proposes to deal with these incompatibilities. ADR submissions without a sufficient backwards compatibility treatise may be rejected outright.
+
+### Positive
+
+{positive consequences}
+
+### Negative
+
+{negative consequences}
+
+### Neutral
+
+{neutral consequences}
+
+## Further Discussions
+
+While an ADR is in the DRAFT or PROPOSED stage, this section should contain a summary of issues to be solved in future iterations (usually referencing comments from a pull-request discussion).
+Later, this section can optionally list ideas or improvements the author or reviewers found during the analysis of this ADR.
+
+## Test Cases [optional]
+
+Test cases for an implementation are mandatory for ADRs that are affecting consensus changes. Other ADRs can choose to include links to test cases if applicable.
+
+## References
+
+- {reference link}


### PR DESCRIPTION
This PR adds a `CONTRIBUTING.md` file with the contributing guidelines and the templates to open new issues and PRs 