### PR TITLE
chore(deps): bump cosmwasm-std from 1.1.9 to 1.3.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,6 +46,7 @@ jobs:
         if: env.GIT_DIFF
         uses: actions-rs/tarpaulin@v0.1.3
         with:
+          version: 0.22.0
           args: '--avoid-cfg-tarpaulin'
 
       - name: Upload coverage 📤

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bnum"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "845141a4fade3f790628b7daaaa298a25b204fb28907eb54febe5142db6ce653"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -70,9 +76,9 @@ checksum = "722e23542a15cea1f65d4a1419c4cfd7a26706c70871a13a04238ca3f40f1661"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.1.9"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "227315dc11f0bb22a273d0c43d3ba8ef52041c42cf959f09045388a89c57e661"
+checksum = "0d076a08ec01ed23c4396aca98ec73a38fa1fee5f310465add52b4108181c7a8"
 dependencies = [
  "digest 0.10.5",
  "ed25519-zebra",
@@ -83,9 +89,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.1.9"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fca30d51f7e5fbfa6440d8b10d7df0231bdf77e97fd3fe5d0cb79cc4822e50c"
+checksum = "dec361f3c09d7b41221948fc17be9b3c96cb58e55a02f82da36f888a651f2584"
 dependencies = [
  "syn 1.0.104",
 ]
@@ -116,11 +122,12 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.1.9"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b13d5a84d15cf7be17dc249a21588cdb0f7ef308907c50ce2723316a7d79c3dc"
+checksum = "1f6dc2ee23313add5ecacc3ccac217b9967ad9d2d11bd56e5da6aa65a9da6138"
 dependencies = [
  "base64",
+ "bnum",
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derivative",
@@ -129,8 +136,8 @@ dependencies = [
  "schemars",
  "serde",
  "serde-json-wasm",
+ "sha2 0.10.6",
  "thiserror",
- "uint",
 ]
 
 [[package]]
@@ -151,12 +158,6 @@ checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "crunchy"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
@@ -821,9 +822,9 @@ dependencies = [
 
 [[package]]
 name = "serde-json-wasm"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479b4dbc401ca13ee8ce902851b834893251404c4f3c65370a49e047a6be09a5"
+checksum = "16a62a1fad1e1828b24acac8f2b468971dade7b8c3c2e672bcadefefb1f8c137"
 dependencies = [
  "serde",
 ]
@@ -922,12 +923,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1012,18 +1007,6 @@ name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
-
-[[package]]
-name = "uint"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45526d29728d135c2900b0d30573fe3ee79fceb12ef534c7bb30e810a91b601"
-dependencies = [
- "byteorder",
- "crunchy",
- "hex",
- "static_assertions",
-]
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 
 [workspace.dependencies]
 # Cosmwasm related dependencies
-cosmwasm-std = "1.1.9"
+cosmwasm-std = "1.2.7"
 cosmwasm-storage = "1.1.9"
 cosmwasm-schema = "1.2.7"
 cw-storage-plus = "0.16.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 
 [workspace.dependencies]
 # Cosmwasm related dependencies
-cosmwasm-std = "1.2.7"
+cosmwasm-std = "1.3.0"
 cosmwasm-storage = "1.1.9"
 cosmwasm-schema = "1.2.7"
 cw-storage-plus = "0.16.0"

--- a/contracts/poap-manager/src/contract.rs
+++ b/contracts/poap-manager/src/contract.rs
@@ -300,7 +300,7 @@ mod tests {
         assert_eq!(
             instantiate(deps.as_mut(), env, info, invalid_msg).unwrap_err(),
             ContractError::Std(StdError::generic_err(
-                "Invalid input: human address too short"
+                "Invalid input: human address too short for this mock implementation (must be >= 3)."
             ))
         )
     }
@@ -422,7 +422,7 @@ mod tests {
         assert_eq!(
             execute(deps.as_mut(), env, info, msg).unwrap_err(),
             ContractError::Std(StdError::generic_err(
-                "Invalid input: human address too short"
+                "Invalid input: human address too short for this mock implementation (must be >= 3)."
             ))
         )
     }
@@ -454,7 +454,7 @@ mod tests {
         assert_eq!(
             execute(deps.as_mut(), env, info, msg).unwrap_err(),
             ContractError::Std(StdError::generic_err(
-                "Invalid input: human address too short"
+                "Invalid input: human address too short for this mock implementation (must be >= 3)."
             ))
         )
     }
@@ -488,7 +488,7 @@ mod tests {
         assert_eq!(
             execute(deps.as_mut(), env, info, msg).unwrap_err(),
             ContractError::Std(StdError::generic_err(
-                "Invalid input: human address too short"
+                "Invalid input: human address too short for this mock implementation (must be >= 3)."
             ))
         )
     }

--- a/contracts/remarkables/src/contract.rs
+++ b/contracts/remarkables/src/contract.rs
@@ -498,7 +498,7 @@ mod tests {
             assert_eq!(
                 instantiate(deps.as_mut(), env, info, invalid_msg).unwrap_err(),
                 ContractError::Std(StdError::generic_err(
-                    "Invalid input: human address too short"
+                    "Invalid input: human address too short for this mock implementation (must be >= 3)."
                 ))
             )
         }
@@ -928,7 +928,7 @@ mod tests {
             assert_eq!(
                 execute(deps.as_mut(), env, info, msg).unwrap_err(),
                 ContractError::Std(StdError::generic_err(
-                    "Invalid input: human address too short"
+                    "Invalid input: human address too short for this mock implementation (must be >= 3)."
                 ))
             )
         }

--- a/contracts/tips/src/contract.rs
+++ b/contracts/tips/src/contract.rs
@@ -750,7 +750,7 @@ mod tests {
 
         assert_eq!(
             ContractError::Std(StdError::generic_err(
-                "Invalid input: human address too short"
+                "Invalid input: human address too short for this mock implementation (must be >= 3)."
             )),
             tip_error
         );
@@ -1589,7 +1589,7 @@ mod tests {
 
         assert_eq!(
             ContractError::Std(StdError::generic_err(
-                "Invalid input: human address too short"
+                "Invalid input: human address too short for this mock implementation (must be >= 3)."
             )),
             error
         );


### PR DESCRIPTION
## Description

Closes: #192 

This PR bumps cosmwasm-std to 1.3.0

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos-contracts/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos-contracts/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed contract logic
- [ ] reviewed contract security
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)