### PR TITLE
fix(poap): handle the cw_ownable messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,7 +748,7 @@ dependencies = [
 
 [[package]]
 name = "poap"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/contracts/poap/Cargo.toml
+++ b/contracts/poap/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "poap"
-version = "2.0.0"
-authors = ["Manuel <manuel@forbole.com>"]
+version = "2.0.1"
+authors = ["Manuel <manuel@desmos.network>"]
 edition = "2021"
 
 exclude = [

--- a/contracts/poap/src/contract_tests.rs
+++ b/contracts/poap/src/contract_tests.rs
@@ -1356,3 +1356,24 @@ fn can_approve_all_and_revoke_all() {
         )
         .unwrap();
 }
+
+#[test]
+fn only_admin_can_initiate_the_ownership_transfer() {
+    let mut deps = mock_dependencies();
+    let contract = setup_contract(deps.as_mut(), true, true, None, None);
+    let msg = ExecuteMsg::UpdateOwnership(cw_ownable::Action::TransferOwnership {
+        new_owner: USER.to_string(),
+        expiry: None,
+    });
+
+    // Check that a random user can't initiate the ownership transfer.
+    let err = contract
+        .execute(deps.as_mut(), mock_env(), mock_info(USER, &[]), msg.clone())
+        .unwrap_err();
+    assert_eq!(Ownership(OwnershipError::NotOwner), err);
+
+    // Check that the admin can initiate the ownership transfer.
+    contract
+        .execute(deps.as_mut(), mock_env(), mock_info(ADMIN, &[]), msg)
+        .unwrap();
+}

--- a/contracts/poap/src/msg.rs
+++ b/contracts/poap/src/msg.rs
@@ -248,6 +248,7 @@ where
             ExecuteMsg::RevokeAll { operator } => Cw721BaseExecuteMsg::RevokeAll { operator },
             ExecuteMsg::Burn { token_id } => Cw721BaseExecuteMsg::Burn { token_id },
             ExecuteMsg::Extension { msg } => Cw721BaseExecuteMsg::Extension { msg },
+            ExecuteMsg::UpdateOwnership(action) => Cw721BaseExecuteMsg::UpdateOwnership(action),
             _ => unreachable!("cannot convert {:?} to Cw721BaseExecuteMsg", execute_msg),
         }
     }
@@ -326,6 +327,7 @@ where
                 Cw721BaseQueryMsg::AllTokens { start_after, limit }
             }
             QueryMsg::Extension { msg } => Cw721BaseQueryMsg::Extension { msg },
+            QueryMsg::Ownership {} => Cw721BaseQueryMsg::Ownership {},
             _ => unreachable!("cannot convert {:?} to Cw721BaseQueryMsg", query_msg),
         }
     }


### PR DESCRIPTION
## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This PR addresses a bug that was preventing users from updating the administrator of the POAP contract.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos-contracts/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos-contracts/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed contract logic
- [ ] reviewed contract security
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)